### PR TITLE
Enable https/wss as an option

### DIFF
--- a/y-serve-worker/src/config.rs
+++ b/y-serve-worker/src/config.rs
@@ -3,9 +3,11 @@ use worker::{Env, RouteContext};
 use y_serve_core::auth::Authenticator;
 
 const AUTH_KEY: &str = "AUTH_KEY";
+const USE_HTTPS: &str = "USE_HTTPS";
 
 pub struct Configuration {
     pub auth: Option<Authenticator>,
+    pub use_https: bool,
 }
 
 pub trait Get {
@@ -25,18 +27,19 @@ impl Get for &Env {
 }
 
 impl Configuration {
-    fn new(auth_key: Option<String>) -> Result<Self> {
+    fn new(auth_key: Option<String>, use_https: bool) -> Result<Self> {
         let auth = if let Some(auth_key) = auth_key {
             Some(Authenticator::new(&auth_key)?)
         } else {
             None
         };
 
-        Ok(Self { auth })
+        Ok(Self { auth, use_https })
     }
 
     pub fn from<T: Get>(ctx: T) -> Result<Self> {
         let auth_key = ctx.get(AUTH_KEY);
-        Configuration::new(auth_key)
+        let use_https = ctx.get(USE_HTTPS).map(|s| s != "false").unwrap_or(false);
+        Configuration::new(auth_key, use_https)
     }
 }

--- a/y-serve-worker/src/lib.rs
+++ b/y-serve-worker/src/lib.rs
@@ -106,7 +106,8 @@ async fn auth_doc(req: Request, ctx: RouteContext<()>) -> Result<Response> {
         None
     };
 
-    let base_url = format!("ws://{}/doc/ws", host);
+    let schema = if config.use_https { "wss" } else { "ws" };
+    let base_url = format!("{schema}://{host}/doc/ws");
     Response::from_json(&AuthDocResponse {
         base_url,
         doc_id: doc_id.to_string(),

--- a/y-serve-worker/wrangler.toml
+++ b/y-serve-worker/wrangler.toml
@@ -13,6 +13,9 @@ bindings = [
   { name = "Y_SERVE", class_name = "YServe" }
 ]
 
+[env.production]
+vars = { USE_HTTPS = "true" }
+
 [[migrations]]
 tag = "v1"
 new_classes = ["YServe"]

--- a/y-serve/src/main.rs
+++ b/y-serve/src/main.rs
@@ -41,6 +41,9 @@ enum ServSubcommand {
 
         #[clap(long)]
         auth: Option<String>,
+
+        #[clap(long)]
+        use_https: bool,
     },
 
     Dump {
@@ -94,6 +97,7 @@ async fn main() -> Result<()> {
             checkpoint_freq_seconds,
             store_path,
             auth,
+            use_https,
         } => {
             let auth = if let Some(auth) = auth {
                 Some(Authenticator::new(auth)?)
@@ -113,6 +117,7 @@ async fn main() -> Result<()> {
                 store,
                 std::time::Duration::from_secs(*checkpoint_freq_seconds),
                 auth,
+                *use_https,
             )
             .await?;
 

--- a/y-serve/src/server.rs
+++ b/y-serve/src/server.rs
@@ -40,6 +40,7 @@ pub struct Server {
     store: Arc<Box<dyn Store>>,
     checkpoint_freq: Duration,
     authenticator: Option<Authenticator>,
+    use_https: bool,
 }
 
 impl Server {
@@ -47,12 +48,14 @@ impl Server {
         store: Box<dyn Store>,
         checkpoint_freq: Duration,
         authenticator: Option<Authenticator>,
+        use_https: bool,
     ) -> Result<Self> {
         Ok(Self {
             docs: DashMap::new(),
             store: Arc::new(store),
             checkpoint_freq,
             authenticator,
+            use_https,
         })
     }
 
@@ -261,7 +264,8 @@ async fn auth_doc(
         None
     };
 
-    let base_url = format!("ws://{}/doc/ws", host);
+    let schema = if server_state.use_https { "wss" } else { "ws" };
+    let base_url = format!("{schema}://{host}/doc/ws");
     Ok(Json(AuthDocResponse {
         base_url,
         doc_id,


### PR DESCRIPTION
We need to return a fully-qualified URL to the client to connect to. The server itself doesn't know by default (or from a request) whether it is behind an encrypting reverse proxy, so it doesn't know whether it should return a `ws://` or `wss://` URL. The solution is simply to tell the server when we want a `wss://` URL instead.

In the native server, this is invoked by passing `--use-https` when starting the server. For the cloudflare worker, it's invoked by setting the `USE_HTTPS` variable to `true`.

This also sets the production config (used for staging) so that it uses `wss://`.