### PR TITLE
Satisfy new fmt rule in latest rustc

### DIFF
--- a/crates/y-sweet-worker/src/server_context.rs
+++ b/crates/y-sweet-worker/src/server_context.rs
@@ -40,7 +40,7 @@ impl ServerContext {
         if self.auth.is_none() {
             let auth_key = {
                 let Some(auth_key) = &self.config.auth_key else {
-                    return Ok(None)
+                    return Ok(None);
                 };
                 auth_key.to_owned()
             };


### PR DESCRIPTION
The rust formatter got stricter. Since our rustfmt check uses the latest rust, our current build now fails.