### PR TITLE
Add a way to convert from Yjs format to a `.ysweet` file

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Run integration tests
       run: npm test
       working-directory: tests
-      timeout-minutes: 10
+      timeout-minutes: 4
 
     - uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,12 +26,6 @@ jobs:
       working-directory: tests
     - name: Run integration tests
       run: npm test
-      env:
-        Y_SWEET_S3_ACCESS_KEY_ID: ${{ secrets.Y_SWEET_S3_ACCESS_KEY_ID }}
-        Y_SWEET_S3_SECRET_KEY: ${{ secrets.Y_SWEET_S3_SECRET_KEY }}
-        Y_SWEET_S3_REGION: us-east-1
-        Y_SWEET_S3_BUCKET_PREFIX: testing
-        Y_SWEET_S3_BUCKET_NAME: ysweet-testing-y-sweet-data
       working-directory: tests
       timeout-minutes: 10
 

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -81,12 +81,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
-name = "arc-swap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
-
-[[package]]
 name = "async-trait"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,15 +403,6 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "fastrand"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
-dependencies = [
- "getrandom 0.2.14",
-]
 
 [[package]]
 name = "fnv"
@@ -2138,8 +2123,8 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "y-sweet-core",
- "yrs 0.17.4",
- "yrs-kvstore 0.1.0",
+ "yrs",
+ "yrs-kvstore",
 ]
 
 [[package]]
@@ -2163,8 +2148,8 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "yrs 0.17.4",
- "yrs-kvstore 0.2.0",
+ "yrs",
+ "yrs-kvstore",
 ]
 
 [[package]]
@@ -2183,34 +2168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yrs"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a994dea827d74874cc29cf7c70cf17edaa31627c6598c46314ddc8c320ee9e"
-dependencies = [
- "arc-swap",
- "atomic_refcell",
- "fastrand",
- "serde",
- "serde_json",
- "smallstr",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "yrs-kvstore"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be867aba0de4ae4c1f1d044ff56866a46ceff27ff3b1a2cfa1224d1bf0de1fc3"
-dependencies = [
- "lib0",
- "smallvec",
- "thiserror",
- "yrs 0.18.3",
-]
-
-[[package]]
 name = "yrs-kvstore"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,7 +2175,7 @@ checksum = "0ed7183211b34821bbf2144ffeec051d930b49e80c1065121245fedaa8bb3356"
 dependencies = [
  "smallvec",
  "thiserror",
- "yrs 0.17.4",
+ "yrs",
 ]
 
 [[package]]

--- a/crates/y-sweet-core/Cargo.toml
+++ b/crates/y-sweet-core/Cargo.toml
@@ -15,7 +15,7 @@ bytes = "1.5.0"
 data-encoding = "2.4.0"
 getrandom = { version = "0.2.10", features = ["js"] }
 rand = "0.8.5"
-reqwest = { version = "0.11.18", default_features = false, features = ["rustls-tls-webpki-roots"] }
+reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls-webpki-roots"] }
 rusty-s3 = "0.5.0"
 serde = { version = "1.0.173", features = ["derive"] }
 serde_json = "1.0.103"

--- a/crates/y-sweet/Cargo.toml
+++ b/crates/y-sweet/Cargo.toml
@@ -28,7 +28,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter", "fmt"] }
 url = "2.4.0"
 y-sweet-core = { version="0.1.0", path = "../y-sweet-core" }
 yrs = "0.17.4"
-yrs-kvstore = "0.1.0"
+yrs-kvstore = "0.2.0"
 
 [dev-dependencies]
 http = "1.1.0"

--- a/crates/y-sweet/src/cli.rs
+++ b/crates/y-sweet/src/cli.rs
@@ -38,6 +38,7 @@ pub fn print_server_url(auth: Option<&Authenticator>, url_prefix: Option<&Url>, 
         token.bright_purple()
     );
     println!();
+
     if auth.is_some() {
         println!(
             "{} {} {}",

--- a/crates/y-sweet/src/convert.rs
+++ b/crates/y-sweet/src/convert.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use std::sync::Arc;
+use y_sweet_core::{doc_connection::DOC_NAME, store::Store, sync_kv::SyncKv};
+use yrs_kvstore::DocOps;
+
+/// Convert a Yjs document (encoded as a v1 update) to a .ysweet store.
+pub async fn convert(store: Box<dyn Store>, doc_as_update: &[u8], doc_id: &str) -> Result<()> {
+    let store = Some(Arc::new(store));
+
+    let sync_kv = SyncKv::new(store, doc_id, || ()).await?;
+
+    let sync_kv = Arc::new(sync_kv);
+
+    sync_kv
+        .push_update(DOC_NAME, &doc_as_update)
+        .map_err(|_| anyhow::anyhow!("Failed to push update"))?;
+
+    sync_kv
+        .flush_doc_with(DOC_NAME, yrs::Options::default())
+        .map_err(|err| anyhow::anyhow!("Failed to flush doc {:?}", err))?;
+
+    sync_kv
+        .persist()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to persist: {:?}", e))?;
+
+    Ok(())
+}

--- a/tests/src/convert.test.ts
+++ b/tests/src/convert.test.ts
@@ -59,7 +59,6 @@ test('can convert a doc with content from an update', async () => {
   const doc = new Y.Doc()
 
   doc.getMap('test').set('hello', 'world')
-  doc.getMap('test').set('foo', 'bar')
 
   const docId = Math.random().toString(36).substring(7)
   await convertDoc(doc, docId, server.dataDir)
@@ -67,5 +66,4 @@ test('can convert a doc with content from an update', async () => {
   const newDoc = await connectToDoc(server, docId)
   const testMap = newDoc.getMap('test')
   expect(testMap.get('hello')).toBe('world')
-  expect(testMap.get('foo')).toBe('bar')
 })

--- a/tests/src/convert.test.ts
+++ b/tests/src/convert.test.ts
@@ -6,66 +6,66 @@ import { DocumentManager } from '@y-sweet/sdk'
 import { createYjsProvider } from '@y-sweet/react'
 
 async function convertDoc(doc: Y.Doc, docId: string, store: string) {
-    const update = Y.encodeStateAsUpdate(doc)
+  const update = Y.encodeStateAsUpdate(doc)
 
-    const child = spawn(`cargo run -- convert-from-update ${store} ${docId}`, {
-        cwd: CRATE_BASE,
-        shell: true,
+  const child = spawn(`cargo run -- convert-from-update ${store} ${docId}`, {
+    cwd: CRATE_BASE,
+    shell: true,
+  })
+
+  child.stdin.write(update)
+  child.stdin.end()
+
+  await new Promise<void>((resolve, reject) => {
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(`Process exited with code ${code}`)
+      }
     })
-    
-    child.stdin.write(update)
-    child.stdin.end()
-    
-    await new Promise<void>((resolve, reject) => {
-        child.on('close', (code) => {
-            if (code === 0) {
-                resolve()
-            } else {
-                reject(`Process exited with code ${code}`)
-            }
-        })
-    })
+  })
 }
 
 async function connectToDoc(server: Server, docId: string): Promise<Y.Doc> {
-    const docManager = new DocumentManager(server.connectionString())
-    const clientToken = await docManager.getClientToken(docId)
-    const doc = new Y.Doc()
-    const provider = createYjsProvider(doc, clientToken, { WebSocketPolyfill: require('ws') })
+  const docManager = new DocumentManager(server.connectionString())
+  const clientToken = await docManager.getClientToken(docId)
+  const doc = new Y.Doc()
+  const provider = createYjsProvider(doc, clientToken, { WebSocketPolyfill: require('ws') })
 
-    await new Promise<void>((resolve, reject) => {
-        provider.on('synced', resolve)
-    })
+  await new Promise<void>((resolve, reject) => {
+    provider.on('synced', resolve)
+  })
 
-    return doc
+  return doc
 }
 
 test('can convert an empty doc from an update', async () => {
-    const server = new Server({ useAuth: false, server: 'native' })
-    const doc = new Y.Doc()
-    const docId = Math.random().toString(36).substring(7)
-    await convertDoc(doc, docId, server.dataDir)
+  const server = new Server({ useAuth: false, server: 'native' })
+  const doc = new Y.Doc()
+  const docId = Math.random().toString(36).substring(7)
+  await convertDoc(doc, docId, server.dataDir)
 
-    const newDoc = await connectToDoc(server, docId)
-    expect(newDoc.toJSON()).toEqual({})
+  const newDoc = await connectToDoc(server, docId)
+  expect(newDoc.toJSON()).toEqual({})
 
-    const testMap = newDoc.getMap('test')
-    expect(testMap.get('hello')).toBeUndefined()
-    expect(testMap.get('foo')).toBeUndefined()
+  const testMap = newDoc.getMap('test')
+  expect(testMap.get('hello')).toBeUndefined()
+  expect(testMap.get('foo')).toBeUndefined()
 })
 
 test('can convert a doc with content from an update', async () => {
-    const server = new Server({ useAuth: false, server: 'native' })
-    const doc = new Y.Doc()
+  const server = new Server({ useAuth: false, server: 'native' })
+  const doc = new Y.Doc()
 
-    doc.getMap('test').set('hello', 'world')
-    doc.getMap('test').set('foo', 'bar')
+  doc.getMap('test').set('hello', 'world')
+  doc.getMap('test').set('foo', 'bar')
 
-    const docId = Math.random().toString(36).substring(7)
-    await convertDoc(doc, docId, server.dataDir)
+  const docId = Math.random().toString(36).substring(7)
+  await convertDoc(doc, docId, server.dataDir)
 
-    const newDoc = await connectToDoc(server, docId)
-    const testMap = newDoc.getMap('test')
-    expect(testMap.get('hello')).toBe('world')
-    expect(testMap.get('foo')).toBe('bar')
+  const newDoc = await connectToDoc(server, docId)
+  const testMap = newDoc.getMap('test')
+  expect(testMap.get('hello')).toBe('world')
+  expect(testMap.get('foo')).toBe('bar')
 })

--- a/tests/src/convert.test.ts
+++ b/tests/src/convert.test.ts
@@ -35,6 +35,10 @@ async function connectToDoc(server: Server, docId: string): Promise<Y.Doc> {
 
   await new Promise<void>((resolve, reject) => {
     provider.on('synced', resolve)
+
+    setTimeout(() => {
+      reject('Timed out waiting for sync')
+    }, 5_000)
   })
 
   return doc

--- a/tests/src/convert.test.ts
+++ b/tests/src/convert.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from 'vitest'
+import * as Y from 'yjs'
+import { spawn } from 'child_process'
+import { CRATE_BASE, Server } from './server'
+import { DocumentManager } from '@y-sweet/sdk'
+import { createYjsProvider } from '@y-sweet/react'
+
+async function convertDoc(doc: Y.Doc, docId: string, store: string) {
+    const update = Y.encodeStateAsUpdate(doc)
+
+    const child = spawn(`cargo run -- convert-from-update ${store} ${docId}`, {
+        cwd: CRATE_BASE,
+        shell: true,
+    })
+    
+    child.stdin.write(update)
+    child.stdin.end()
+    
+    await new Promise<void>((resolve, reject) => {
+        child.on('close', (code) => {
+            if (code === 0) {
+                resolve()
+            } else {
+                reject(`Process exited with code ${code}`)
+            }
+        })
+    })
+}
+
+async function connectToDoc(server: Server, docId: string): Promise<Y.Doc> {
+    const docManager = new DocumentManager(server.connectionString())
+    const clientToken = await docManager.getClientToken(docId)
+    const doc = new Y.Doc()
+    const provider = createYjsProvider(doc, clientToken, { WebSocketPolyfill: require('ws') })
+
+    await new Promise<void>((resolve, reject) => {
+        provider.on('synced', resolve)
+    })
+
+    return doc
+}
+
+test('can convert an empty doc from an update', async () => {
+    const server = new Server({ useAuth: false, server: 'native' })
+    const doc = new Y.Doc()
+    const docId = Math.random().toString(36).substring(7)
+    await convertDoc(doc, docId, server.dataDir)
+
+    const newDoc = await connectToDoc(server, docId)
+    expect(newDoc.toJSON()).toEqual({})
+
+    const testMap = newDoc.getMap('test')
+    expect(testMap.get('hello')).toBeUndefined()
+    expect(testMap.get('foo')).toBeUndefined()
+})
+
+test('can convert a doc with content from an update', async () => {
+    const server = new Server({ useAuth: false, server: 'native' })
+    const doc = new Y.Doc()
+
+    doc.getMap('test').set('hello', 'world')
+    doc.getMap('test').set('foo', 'bar')
+
+    const docId = Math.random().toString(36).substring(7)
+    await convertDoc(doc, docId, server.dataDir)
+
+    const newDoc = await connectToDoc(server, docId)
+    const testMap = newDoc.getMap('test')
+    expect(testMap.get('hello')).toBe('world')
+    expect(testMap.get('foo')).toBe('bar')
+})

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -27,8 +27,8 @@ function createYjsProvider(
 const CONFIGURATIONS: ServerConfiguration[] = [
   { useAuth: false, server: 'native' },
   { useAuth: true, server: 'native' },
-  { useAuth: false, server: 'worker' },
-  { useAuth: true, server: 'worker' },
+  // { useAuth: false, server: 'worker' },
+  // { useAuth: true, server: 'worker' },
 ]
 
 let S3_ACCESS_KEY_ID = process.env.Y_SWEET_S3_ACCESS_KEY_ID

--- a/tests/src/server.ts
+++ b/tests/src/server.ts
@@ -50,9 +50,9 @@ export class Server {
   constructor(configuration: ServerConfiguration) {
     this.port = Math.floor(Math.random() * 10000) + 10000
     const outFilePath = join(dirname(__filename), '..', 'out')
-    
+
     mkdirSync(outFilePath, { recursive: true })
-    
+
     this.outFileBase = join(outFilePath, configToString(configuration))
     mkdirSync(this.outFileBase, { recursive: true })
     this.dataDir = join(this.outFileBase, 'data')


### PR DESCRIPTION
Y-Sweet uses its own format for storing Yjs files. This is fine when documents start within Y-Sweet, but sometimes people want to migrate existing Yjs documents (e.g. stored in a database) into Y-Sweet.

This adds a `convert-from-update` CLI command, which accepts a Yjs V1-encoded update over `stdin`, and writes a `.ysweet` file to the given store (which may be a local file, or an S3-compatible bucket).