### PR TITLE
Turn y-sweet crate into a library

### DIFF
--- a/crates/y-sweet-core/src/sync/awareness.rs
+++ b/crates/y-sweet-core/src/sync/awareness.rs
@@ -180,9 +180,6 @@ impl Awareness {
 
     /// Applies an update (incoming from remote channel or generated using [Awareness::update] /
     /// [Awareness::update_with_clients] methods) and modifies a state of a current instance.
-    ///
-    /// If current instance has an observer channel (see: [Awareness::with_observer]), applied
-    /// changes will also be emitted as events.
     pub fn apply_update(&mut self, update: AwarenessUpdate) -> Result<(), Error> {
         let mut added = Vec::new();
         let mut updated = Vec::new();
@@ -201,7 +198,7 @@ impl Awareness {
                         if is_null {
                             // never let a remote client remove this local state
                             if client_id == self.doc.client_id()
-                                && self.states.get(&client_id).is_some()
+                                && self.states.contains_key(&client_id)
                             {
                                 // remote client removed the local state. Do not remote state. Broadcast a message indicating
                                 // that this client still exists by increasing the clock

--- a/crates/y-sweet-core/src/sync_kv.rs
+++ b/crates/y-sweet-core/src/sync_kv.rs
@@ -84,6 +84,10 @@ impl SyncKv {
     pub fn len(&self) -> usize {
         self.data.lock().unwrap().len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.lock().unwrap().is_empty()
+    }
 }
 
 impl<'d> DocOps<'d> for SyncKv {}

--- a/crates/y-sweet/README.md
+++ b/crates/y-sweet/README.md
@@ -11,3 +11,7 @@
 - Deploys as a native Linux process, or as a WebAssembly module on Cloudflare's edge.
 - Provides document-level access control via client tokens.
 - Written in Rust with a focus on stability and performance, building on the excellent [y-crdt](https://github.com/y-crdt/y-crdt/) library.
+
+## `y-sweet` crate
+
+The y-sweet crate is primarily intended to be used as a binary, but can also be used as a library. See `main.rs` for usage examples.

--- a/crates/y-sweet/src/convert.rs
+++ b/crates/y-sweet/src/convert.rs
@@ -12,7 +12,7 @@ pub async fn convert(store: Box<dyn Store>, doc_as_update: &[u8], doc_id: &str) 
     let sync_kv = Arc::new(sync_kv);
 
     sync_kv
-        .push_update(DOC_NAME, &doc_as_update)
+        .push_update(DOC_NAME, doc_as_update)
         .map_err(|_| anyhow::anyhow!("Failed to push update"))?;
 
     sync_kv

--- a/crates/y-sweet/src/lib.rs
+++ b/crates/y-sweet/src/lib.rs
@@ -1,0 +1,6 @@
+#![doc = include_str!("../README.md")]
+
+pub mod cli;
+pub mod convert;
+pub mod server;
+pub mod stores;

--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -1,9 +1,5 @@
-#![doc = include_str!("../README.md")]
-
-use crate::stores::filesystem::FileSystemStore;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use cli::{print_auth_message, print_server_url};
 use serde_json::json;
 use std::{
     env,
@@ -14,6 +10,8 @@ use tokio::io::AsyncReadExt;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use url::Url;
+use y_sweet::cli::{print_auth_message, print_server_url};
+use y_sweet::stores::filesystem::FileSystemStore;
 use y_sweet_core::{
     auth::Authenticator,
     store::{
@@ -21,11 +19,6 @@ use y_sweet_core::{
         Store,
     },
 };
-
-mod cli;
-mod convert;
-mod server;
-mod stores;
 
 const DEFAULT_S3_REGION: &str = "us-east-1";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -185,7 +178,7 @@ async fn main() -> Result<()> {
                 print_server_url(auth.as_ref(), url_prefix.as_ref(), addr);
             }
 
-            let server = server::Server::new(
+            let server = y_sweet::server::Server::new(
                 store,
                 std::time::Duration::from_secs(*checkpoint_freq_seconds),
                 auth,
@@ -231,7 +224,7 @@ async fn main() -> Result<()> {
             let mut buf = Vec::new();
             stdin.read_to_end(&mut buf).await?;
 
-            convert::convert(store, &buf, doc_id).await?;
+            y_sweet::convert::convert(store, &buf, doc_id).await?;
         }
         ServSubcommand::Version => {
             println!("{}", VERSION);


### PR DESCRIPTION
- Moves `mod` declarations from `main.rs` into `lib.rs`, so that other crates can import them.
- Decouples `serve` from the creation of the `Router`, so that other crates can nest y-sweet routes inside their own Axum server.
- Fixes a few clippy nitpicks.