### PR TITLE
Remove unwraps in durable object

### DIFF
--- a/crates/y-sweet-worker/Cargo.lock
+++ b/crates/y-sweet-worker/Cargo.lock
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "y-sweet-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "y-sweet-worker"
-version = "0.1.2"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
We don't get very good error messages currently when errors happen inside the durable object; this fixes that.