### PR TITLE
Fix all lint/compilation warnings

### DIFF
--- a/crates/y-sweet-core/Cargo.toml
+++ b/crates/y-sweet-core/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/drifting-in-space/y-sweet"
 [features]
 default = ["sync"]
 sync = ["yrs/sync"]
+single-threaded = []
 
 [dependencies]
 anyhow = "1.0.72"

--- a/crates/y-sweet-core/src/doc_sync.rs
+++ b/crates/y-sweet-core/src/doc_sync.rs
@@ -67,9 +67,7 @@ impl DocWithSyncKv {
 
         let txn = doc.transact();
 
-        let update = txn.encode_state_as_update_v1(&StateVector::default());
-
-        update
+        txn.encode_state_as_update_v1(&StateVector::default())
     }
 
     pub fn apply_update(&self, update: &[u8]) -> Result<()> {

--- a/crates/y-sweet-core/src/sync/mod.rs
+++ b/crates/y-sweet-core/src/sync/mod.rs
@@ -175,7 +175,7 @@ impl Encode for Message {
             }
             Message::Awareness(update) => {
                 encoder.write_var(MSG_AWARENESS);
-                encoder.write_buf(&update.encode_v1())
+                encoder.write_buf(update.encode_v1())
             }
             Message::Custom(tag, data) => {
                 encoder.write_u8(*tag);


### PR DESCRIPTION
Running the tests surfaced the following warning:
```
warning: unexpected `cfg` condition value: `single-threaded`
   --> y-sweet-core/src/sync_kv.rs:198:20
    |
198 |     #[cfg_attr(not(feature = "single-threaded"), async_trait)]
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `default` and `sync`
    = help: consider adding `single-threaded` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

warning: unexpected `cfg` condition value: `single-threaded`
   --> y-sweet-core/src/sync_kv.rs:199:16
    |
199 |     #[cfg_attr(feature = "single-threaded", async_trait(?Send))]
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `default` and `sync`
    = help: consider adding `single-threaded` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```

Added `single-threaded` as a feature and applied clippy's auto-fixes.