### PR TITLE
Fix clippy in Y-Sweet Worker

### DIFF
--- a/crates/y-sweet-worker/src/durable_object.rs
+++ b/crates/y-sweet-worker/src/durable_object.rs
@@ -85,7 +85,7 @@ impl DurableObject for YServe {
     }
 
     async fn fetch(&mut self, req: Request) -> Result<Response> {
-        let env: Env = self.env.clone().into();
+        let env: Env = self.env.clone();
         let req = ServerContext::reconstruct_request(&req)?;
 
         Router::with_data(self)
@@ -113,7 +113,7 @@ impl DurableObject for YServe {
 async fn as_update(req: Request, ctx: RouteContext<&mut YServe>) -> Result<Response> {
     let doc_id = ctx
         .param("doc_id")
-        .ok_or_else(|| "Couldn't parse doc_id")?
+        .ok_or("Couldn't parse doc_id")?
         .to_owned();
     let doc = ctx
         .data
@@ -127,7 +127,7 @@ async fn as_update(req: Request, ctx: RouteContext<&mut YServe>) -> Result<Respo
 async fn update_doc(mut req: Request, ctx: RouteContext<&mut YServe>) -> Result<Response> {
     let doc_id = ctx
         .param("doc_id")
-        .ok_or_else(|| "Couldn't parse doc_id")?
+        .ok_or("Couldn't parse doc_id")?
         .to_owned();
     let doc = ctx
         .data
@@ -143,7 +143,7 @@ async fn update_doc(mut req: Request, ctx: RouteContext<&mut YServe>) -> Result<
 async fn handle_doc_create(req: Request, ctx: RouteContext<&mut YServe>) -> Result<Response> {
     let doc_id = ctx
         .param("doc_id")
-        .ok_or_else(|| "Couldn't parse doc_id")?
+        .ok_or("Couldn't parse doc_id")?
         .to_owned();
     ctx.data
         .get_doc(&req, &doc_id)
@@ -159,7 +159,7 @@ async fn websocket_connect(req: Request, ctx: RouteContext<&mut YServe>) -> Resu
 
     let doc_id = ctx
         .param("doc_id")
-        .ok_or_else(|| "Couldn't parse doc_id")?
+        .ok_or("Couldn't parse doc_id")?
         .to_owned();
     let awareness = ctx
         .data

--- a/crates/y-sweet-worker/src/lib.rs
+++ b/crates/y-sweet-worker/src/lib.rs
@@ -145,7 +145,7 @@ async fn new_doc(
 
     if result.status_code() != 200 {
         let body = match result.body() {
-            ResponseBody::Body(body) => String::from_utf8_lossy(&body).to_string(),
+            ResponseBody::Body(body) => String::from_utf8_lossy(body).to_string(),
             _ => String::new(),
         };
 
@@ -289,7 +289,7 @@ async fn forward_to_durable_object_with_doc_id(
     doc_id: &str,
 ) -> Result<Response> {
     let durable_object = ctx.env.durable_object(DURABLE_OBJECT)?;
-    let stub = durable_object.id_from_name(&doc_id)?.get_stub()?;
+    let stub = durable_object.id_from_name(doc_id)?.get_stub()?;
 
     // Pass server context to durable object.
     let path = req.path();

--- a/crates/y-sweet-worker/src/r2_store.rs
+++ b/crates/y-sweet-worker/src/r2_store.rs
@@ -32,7 +32,7 @@ impl Store for R2Store {
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
         let object = self
             .bucket
-            .get(&self.prefixed_key(key))
+            .get(self.prefixed_key(key))
             .execute()
             .await
             .map_err(|_| StoreError::ConnectionError("Failed to get object".into()))?;
@@ -53,7 +53,7 @@ impl Store for R2Store {
 
     async fn set(&self, key: &str, value: Vec<u8>) -> Result<()> {
         self.bucket
-            .put(&self.prefixed_key(key), value)
+            .put(self.prefixed_key(key), value)
             .execute()
             .await
             .map_err(|e| StoreError::ConnectionError(format!("Failed to put object {e}")))?;


### PR DESCRIPTION
Missed in #260 because `y-sweet-worker` uses a different arch and has to be built/checked separately.