### PR TITLE
Make the container default to serve doc

### DIFF
--- a/crates/Dockerfile
+++ b/crates/Dockerfile
@@ -9,4 +9,4 @@ FROM debian:buster-slim
 
 COPY --from=builder /build/target/release/y-sweet /usr/local/bin/y-sweet
 
-CMD ["y-sweet", "--host=0.0.0.0"]
+CMD ["y-sweet", "serve-doc", "--host=0.0.0.0"]


### PR DESCRIPTION
It appears that the compose file [overrides the command run](https://github.com/jamsocket/y-sweet/blob/main/deploy/docker-compose.yml#L9), so I don't think that needs changing, as long as we want to continue supporting the full-fledged y-sweet experience and aren't sunsetting it.

The docs do make [brief mention of the docker image](https://github.com/jamsocket/y-sweet/blob/main/docs/running.md#docker-image), although I'm not exactly sure if that's really a supported way of running things. Lmk if you have suggestions as to what to say there, otherwise I'll leave it as is given the other options seem to be the more "blessed paths". One option is just to delete the mention of the docker image entirely?