### PR TITLE
Fix windows support

### DIFF
--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -277,6 +277,7 @@ async fn main() -> Result<()> {
                     tracing::info!("Received Ctrl+C, shutting down.");
                 },
                 _ = async {
+                    #[cfg(unix)]
                     match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
                         Ok(mut signal) => signal.recv().await,
                         Err(e) => {
@@ -284,6 +285,9 @@ async fn main() -> Result<()> {
                             std::future::pending::<Option<()>>().await
                         }
                     }
+
+                    #[cfg(not(unix))]
+                    std::future::pending::<Option<()>>().await
                 } => {
                     tracing::info!("Received SIGTERM, shutting down.");
                 }


### PR DESCRIPTION
Using `tokio::signal::unix::signal` breaks the build on windows. Instead we support just the `ctrl_c` handler non non-unix platforms, which is cross-platform.