### PR TITLE
Fix x86 Mac OS Build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,16 +30,16 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --manifest-path=crates/Cargo.toml --target aarch64-apple-darwin
+        args: --manifest-path=crates/Cargo.toml --target aarch64-apple-darwin --release
 
     - name: strip binary
-      run: strip ./crates/target/aarch64-apple-darwin/debug/y-sweet
+      run: strip ./crates/target/aarch64-apple-darwin/release/y-sweet
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
         name: macos-binary-arm64
-        path: ./crates/target/aarch64-apple-darwin/debug/y-sweet
+        path: ./crates/target/aarch64-apple-darwin/release/y-sweet
 
   build-macos-x64:
     runs-on: macos-latest
@@ -59,13 +59,13 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --release --manifest-path=crates/Cargo.toml
+        args: --release --manifest-path=crates/Cargo.toml --target x86_64-apple-darwin
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
         name: macos-binary-x64
-        path: ./crates/target/release/y-sweet 
+        path: ./crates/target/x86_64-apple-darwin/release/y-sweet 
 
   build-linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As surfaced in #270, our `y-sweet-macos-x64` build is actually an `arm64` build.

<img width="842" alt="image" src="https://github.com/user-attachments/assets/5fe354ed-32b2-44ff-8a18-1c4dba55170d">

I traced this down to our build script -- we successfully install the toolchain and set it as default, but that does not set the target type.

In the process I also noticed that our aarch64 MacOS build is a debug build, so I fixed that.