### PR TITLE
Return `baseUrl` from auth endpoint

### DIFF
--- a/crates/y-sweet-core/src/api_types.rs
+++ b/crates/y-sweet-core/src/api_types.rs
@@ -38,9 +38,19 @@ pub struct AuthDocRequest {
 
 #[derive(Serialize)]
 pub struct ClientToken {
+    /// The URL compatible with the y-websocket provider. The provider will append
+    /// a document ID to this string and establish a WebSocket connection.
     pub url: String,
+
+    /// The base URL for document-level endpoints.
+    #[serde(rename = "baseUrl")]
+    pub base_url: String,
+
+    /// The document ID.
     #[serde(rename = "docId")]
     pub doc_id: String,
+
+    /// An optional token that can be used to authenticate the client to the server.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
 }

--- a/crates/y-sweet-core/src/api_types.rs
+++ b/crates/y-sweet-core/src/api_types.rs
@@ -44,7 +44,7 @@ pub struct ClientToken {
 
     /// The base URL for document-level endpoints.
     #[serde(rename = "baseUrl")]
-    pub base_url: String,
+    pub base_url: Option<String>,
 
     /// The document ID.
     #[serde(rename = "docId")]

--- a/crates/y-sweet-worker/src/lib.rs
+++ b/crates/y-sweet-worker/src/lib.rs
@@ -248,6 +248,7 @@ async fn auth_doc(
 
     Ok(ClientToken {
         url,
+        base_url: None,
         doc_id: doc_id.to_string(),
         token,
     })

--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -605,7 +605,13 @@ async fn auth_doc(
         format!("ws://{host}/doc/ws")
     };
 
-    Ok(Json(ClientToken { url, doc_id, token }))
+    let base_url = if let Some(url_prefix) = &server_state.url_prefix {
+        format!("{url_prefix}/d/{doc_id}")
+    } else {
+        format!("http://{host}/d/{doc_id}")
+    };
+
+    Ok(Json(ClientToken { url, base_url, doc_id, token }))
 }
 
 #[cfg(test)]

--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -613,7 +613,7 @@ async fn auth_doc(
 
     Ok(Json(ClientToken {
         url,
-        base_url,
+        base_url: Some(base_url),
         doc_id,
         token,
     }))

--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -611,7 +611,12 @@ async fn auth_doc(
         format!("http://{host}/d/{doc_id}")
     };
 
-    Ok(Json(ClientToken { url, base_url, doc_id, token }))
+    Ok(Json(ClientToken {
+        url,
+        base_url,
+        doc_id,
+        token,
+    }))
 }
 
 #[cfg(test)]

--- a/js-pkg/sdk/src/main.ts
+++ b/js-pkg/sdk/src/main.ts
@@ -17,6 +17,9 @@ export type ClientToken = {
   /** The bare URL of the WebSocket endpoint to connect to. The `doc` string will be appended to this. */
   url: string
 
+  /** The base URL for document-level endpoints. */
+  baseUrl: string
+
   /** A unique identifier for the document that the token connects to. */
   docId: string
 

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeAll, afterAll } from 'vitest'
-import { DocumentManager } from '@y-sweet/sdk'
+import { ClientToken, DocumentManager } from '@y-sweet/sdk'
 import { createYjsProvider as createYjsProvider_, YSweetProviderParams } from '@y-sweet/react'
 import { WebSocket } from 'ws'
 import * as Y from 'yjs'
@@ -13,7 +13,7 @@ import { waitForProviderSync } from './util'
  */
 function createYjsProvider(
   doc: Y.Doc,
-  clientToken: { url: string; docId: string; token?: string },
+  clientToken: ClientToken,
   extraOptions: YSweetProviderParams,
 ) {
   extraOptions = {
@@ -106,6 +106,12 @@ describe.each(CONFIGURATIONS)(
       // the 404 will fail with a 500.
       // Not sure why, but this is a workaround.
       await DOCUMENT_MANANGER.createDoc().catch(() => {})
+    })
+
+    test('Connection token should have baseUrl', async () => {
+      let token = await DOCUMENT_MANANGER.getOrCreateDocAndToken('foobar')
+
+      expect(token.baseUrl).toBeDefined()
     })
 
     test('Create and connect to doc', async () => {


### PR DESCRIPTION
Design doc: https://docs.google.com/document/d/10O4-i9sxUL5-bWjIYqgxbStJGqNCVLfP411J9x-fTFM/edit

This just returns the URL but does not implement any endpoints under it; those will come in a subsequent PR.