### PR TITLE
Implement YSweetConnection class in SDK

### DIFF
--- a/crates/y-sweet-core/src/auth.rs
+++ b/crates/y-sweet-core/src/auth.rs
@@ -323,7 +323,7 @@ impl Authenticator {
                     Err(AuthError::InvalidResource)
                 }
             }
-            _ => Err(AuthError::InvalidResource),
+            Permission::Server => Ok(()), // Server tokens can access any doc.
         }
     }
 

--- a/js-pkg/sdk/src/connection.ts
+++ b/js-pkg/sdk/src/connection.ts
@@ -1,11 +1,13 @@
 import { HttpClient } from './http'
 import { ClientToken } from './types'
 
-export class YSweetConnection {
+export class DocConnection {
   private client: HttpClient
+  private docId: string
 
   constructor(clientToken: ClientToken) {
-    this.client = new HttpClient(clientToken.url, clientToken.token ?? null)
+    this.client = new HttpClient(clientToken.baseUrl, clientToken.token ?? null)
+    this.docId = clientToken.docId
   }
 
   /**
@@ -23,13 +25,12 @@ export class YSweetConnection {
    * })
    * ```
    *
-   * @param docId
    * @returns
    */
-  public async getDocAsUpdate(docId: string): Promise<Uint8Array> {
-    const result = await this.client.request(`doc/${docId}/as-update`, 'GET')
+  public async getAsUpdate(): Promise<Uint8Array> {
+    const result = await this.client.request(`as-update`, 'GET')
     if (!result.ok) {
-      throw new Error(`Failed to get doc ${docId}: ${result.status} ${result.statusText}`)
+      throw new Error(`Failed to get doc ${this.docId}: ${result.status} ${result.statusText}`)
     }
 
     let buffer = await result.arrayBuffer()
@@ -50,14 +51,13 @@ export class YSweetConnection {
    * await manager.updateDoc(docId, update)
    * ```
    *
-   * @param docId
    * @param update
    */
-  public async updateDoc(docId: string, update: Uint8Array): Promise<void> {
-    const result = await this.client.request(`doc/${docId}/update`, 'POST', update)
+  public async updateDoc(update: Uint8Array): Promise<void> {
+    const result = await this.client.request(`update`, 'POST', update)
 
     if (!result.ok) {
-      throw new Error(`Failed to update doc ${docId}: ${result.status} ${result.statusText}`)
+      throw new Error(`Failed to update doc ${this.docId}: ${result.status} ${result.statusText}`)
     }
   }
 }

--- a/js-pkg/sdk/src/connection.ts
+++ b/js-pkg/sdk/src/connection.ts
@@ -1,0 +1,63 @@
+import { HttpClient } from './http'
+import { ClientToken } from './types'
+
+export class YSweetConnection {
+  private client: HttpClient
+
+  constructor(clientToken: ClientToken) {
+    this.client = new HttpClient(clientToken.url, clientToken.token ?? null)
+  }
+
+  /**
+   * Returns an entire document, represented as a Yjs update byte string.
+   *
+   * This can be turned back into a Yjs document as follows:
+   *
+   * ```typescript
+   * import * as Y from 'yjs'
+   *
+   * let update = await manager.getDocAsUpdate(docId)
+   * let doc = new Y.Doc()
+   * doc.transact(() => {
+   *  Y.applyUpdate(doc, update)
+   * })
+   * ```
+   *
+   * @param docId
+   * @returns
+   */
+  public async getDocAsUpdate(docId: string): Promise<Uint8Array> {
+    const result = await this.client.request(`doc/${docId}/as-update`, 'GET')
+    if (!result.ok) {
+      throw new Error(`Failed to get doc ${docId}: ${result.status} ${result.statusText}`)
+    }
+
+    let buffer = await result.arrayBuffer()
+    return new Uint8Array(buffer)
+  }
+
+  /**
+   * Updates a document with the given Yjs update byte string.
+   *
+   * This can be generated from a Yjs document as follows:
+   *
+   * ```typescript
+   * import * as Y from 'yjs'
+   *
+   * let doc = new Y.Doc()
+   * // Modify the document...
+   * let update = Y.encodeStateAsUpdate(doc)
+   * await manager.updateDoc(docId, update)
+   * ```
+   *
+   * @param docId
+   * @param update
+   */
+  public async updateDoc(docId: string, update: Uint8Array): Promise<void> {
+    const result = await this.client.request(`doc/${docId}/update`, 'POST', update)
+
+    if (!result.ok) {
+      throw new Error(`Failed to update doc ${docId}: ${result.status} ${result.statusText}`)
+    }
+  }
+}

--- a/js-pkg/sdk/src/http.ts
+++ b/js-pkg/sdk/src/http.ts
@@ -1,0 +1,83 @@
+import { YSweetError } from "./error"
+
+/** A type that can be used as an HTTP request body.
+ * If a `Uint8Array` is provided, the body is sent as a raw binary body
+ * with the `Content-Type` header set to `application/octet-stream`.
+ * Otherwise, the body is sent as a JSON body with the `Content-Type`
+ * header set to `application/json`.
+ */
+export type BodyType = Record<string, any> | Uint8Array
+
+export class HttpClient {
+    private token: string | null = null
+    private baseUrl: string
+
+    constructor(baseUrl: string, token: string | null) {
+        this.baseUrl = baseUrl
+        this.token = token
+    }
+
+    public async request(url: string, method: 'GET'): Promise<Response>
+    public async request(url: string, method: 'POST', body: BodyType): Promise<Response>
+
+    public async request(path: string, method: 'GET' | 'POST', body?: BodyType): Promise<Response> {
+        const headers = new Headers()
+        if (this.token) {
+            headers.set('Authorization', `Bearer ${this.token}`)
+        }
+
+        let rawBody: string | Uint8Array
+        if (body instanceof Uint8Array) {
+            headers.set('Content-Type', 'application/octet-stream')
+            rawBody = body
+        } else if (body) {
+            headers.set('Content-Type', 'application/json')
+            rawBody = JSON.stringify(body)
+        }
+
+        // NOTE: In some environments (e.g. NextJS), responses are cached by default. Disabling
+        // the cache using `cache: 'no-store'` causes fetch() to error in other environments
+        // (e.g. Cloudflare Workers). To work around this, we simply add a cache-busting query
+        // param.
+        const cacheBust = generateRandomString()
+        let url = `${this.baseUrl}/${path}?z=${cacheBust}`
+        let result: Response
+        try {
+            result = await fetch(url, {
+                method,
+                body: rawBody!,
+                headers,
+            })
+        } catch (error: any) {
+            if (error.cause?.code === 'ECONNREFUSED') {
+                let { address, port } = error.cause
+                throw new YSweetError({ code: 'ServerRefused', address, port, url })
+            } else {
+                throw new YSweetError({ code: 'Unknown', message: error.toString() })
+            }
+        }
+
+        if (!result.ok) {
+            if (result.status === 401) {
+                if (this.token) {
+                    throw new YSweetError({ code: 'InvalidAuthProvided' })
+                } else {
+                    throw new YSweetError({ code: 'NoAuthProvided' })
+                }
+            }
+
+            throw new YSweetError({
+                code: 'ServerError',
+                status: result.status,
+                message: result.statusText,
+                url,
+            })
+        }
+
+        return result
+    }
+}
+
+function generateRandomString(): string {
+    return Math.random().toString(36).substring(2)
+}

--- a/js-pkg/sdk/src/http.ts
+++ b/js-pkg/sdk/src/http.ts
@@ -1,4 +1,4 @@
-import { YSweetError } from "./error"
+import { YSweetError } from './error'
 
 /** A type that can be used as an HTTP request body.
  * If a `Uint8Array` is provided, the body is sent as a raw binary body
@@ -9,75 +9,75 @@ import { YSweetError } from "./error"
 export type BodyType = Record<string, any> | Uint8Array
 
 export class HttpClient {
-    private token: string | null = null
-    private baseUrl: string
+  private token: string | null = null
+  private baseUrl: string
 
-    constructor(baseUrl: string, token: string | null) {
-        this.baseUrl = baseUrl
-        this.token = token
+  constructor(baseUrl: string, token: string | null) {
+    this.baseUrl = baseUrl
+    this.token = token
+  }
+
+  public async request(url: string, method: 'GET'): Promise<Response>
+  public async request(url: string, method: 'POST', body: BodyType): Promise<Response>
+
+  public async request(path: string, method: 'GET' | 'POST', body?: BodyType): Promise<Response> {
+    const headers = new Headers()
+    if (this.token) {
+      headers.set('Authorization', `Bearer ${this.token}`)
     }
 
-    public async request(url: string, method: 'GET'): Promise<Response>
-    public async request(url: string, method: 'POST', body: BodyType): Promise<Response>
+    let rawBody: string | Uint8Array
+    if (body instanceof Uint8Array) {
+      headers.set('Content-Type', 'application/octet-stream')
+      rawBody = body
+    } else if (body) {
+      headers.set('Content-Type', 'application/json')
+      rawBody = JSON.stringify(body)
+    }
 
-    public async request(path: string, method: 'GET' | 'POST', body?: BodyType): Promise<Response> {
-        const headers = new Headers()
+    // NOTE: In some environments (e.g. NextJS), responses are cached by default. Disabling
+    // the cache using `cache: 'no-store'` causes fetch() to error in other environments
+    // (e.g. Cloudflare Workers). To work around this, we simply add a cache-busting query
+    // param.
+    const cacheBust = generateRandomString()
+    let url = `${this.baseUrl}/${path}?z=${cacheBust}`
+    let result: Response
+    try {
+      result = await fetch(url, {
+        method,
+        body: rawBody!,
+        headers,
+      })
+    } catch (error: any) {
+      if (error.cause?.code === 'ECONNREFUSED') {
+        let { address, port } = error.cause
+        throw new YSweetError({ code: 'ServerRefused', address, port, url })
+      } else {
+        throw new YSweetError({ code: 'Unknown', message: error.toString() })
+      }
+    }
+
+    if (!result.ok) {
+      if (result.status === 401) {
         if (this.token) {
-            headers.set('Authorization', `Bearer ${this.token}`)
+          throw new YSweetError({ code: 'InvalidAuthProvided' })
+        } else {
+          throw new YSweetError({ code: 'NoAuthProvided' })
         }
+      }
 
-        let rawBody: string | Uint8Array
-        if (body instanceof Uint8Array) {
-            headers.set('Content-Type', 'application/octet-stream')
-            rawBody = body
-        } else if (body) {
-            headers.set('Content-Type', 'application/json')
-            rawBody = JSON.stringify(body)
-        }
-
-        // NOTE: In some environments (e.g. NextJS), responses are cached by default. Disabling
-        // the cache using `cache: 'no-store'` causes fetch() to error in other environments
-        // (e.g. Cloudflare Workers). To work around this, we simply add a cache-busting query
-        // param.
-        const cacheBust = generateRandomString()
-        let url = `${this.baseUrl}/${path}?z=${cacheBust}`
-        let result: Response
-        try {
-            result = await fetch(url, {
-                method,
-                body: rawBody!,
-                headers,
-            })
-        } catch (error: any) {
-            if (error.cause?.code === 'ECONNREFUSED') {
-                let { address, port } = error.cause
-                throw new YSweetError({ code: 'ServerRefused', address, port, url })
-            } else {
-                throw new YSweetError({ code: 'Unknown', message: error.toString() })
-            }
-        }
-
-        if (!result.ok) {
-            if (result.status === 401) {
-                if (this.token) {
-                    throw new YSweetError({ code: 'InvalidAuthProvided' })
-                } else {
-                    throw new YSweetError({ code: 'NoAuthProvided' })
-                }
-            }
-
-            throw new YSweetError({
-                code: 'ServerError',
-                status: result.status,
-                message: result.statusText,
-                url,
-            })
-        }
-
-        return result
+      throw new YSweetError({
+        code: 'ServerError',
+        status: result.status,
+        message: result.statusText,
+        url,
+      })
     }
+
+    return result
+  }
 }
 
 function generateRandomString(): string {
-    return Math.random().toString(36).substring(2)
+  return Math.random().toString(36).substring(2)
 }

--- a/js-pkg/sdk/src/main.ts
+++ b/js-pkg/sdk/src/main.ts
@@ -1,3 +1,4 @@
+import { YSweetConnection } from './connection'
 import { YSweetError } from './error'
 import { HttpClient } from './http'
 import type { DocCreationResult, ClientToken, CheckStoreResult } from './types'
@@ -128,6 +129,11 @@ export class DocumentManager {
     if (!result.ok) {
       throw new Error(`Failed to update doc ${docId}: ${result.status} ${result.statusText}`)
     }
+  }
+
+  public async getConnection(docId: string): Promise<YSweetConnection> {
+    const clientToken = await this.getClientToken(docId)
+    return new YSweetConnection(clientToken)
   }
 }
 

--- a/js-pkg/sdk/src/main.ts
+++ b/js-pkg/sdk/src/main.ts
@@ -105,13 +105,8 @@ export class DocumentManager {
    * @returns The document as a Yjs update byte string
    */
   public async getDocAsUpdate(docId: string): Promise<Uint8Array> {
-    const result = await this.client.request(`doc/${docId}/as-update`, 'GET')
-    if (!result.ok) {
-      throw new Error(`Failed to get doc ${docId}: ${result.status} ${result.statusText}`)
-    }
-
-    let buffer = await result.arrayBuffer()
-    return new Uint8Array(buffer)
+    const connection = await this.getDocConnection(docId)
+    return await connection.getAsUpdate()
   }
 
   /**
@@ -121,11 +116,8 @@ export class DocumentManager {
    * @param update The Yjs update byte string to apply to the document.
    */
   public async updateDoc(docId: string, update: Uint8Array): Promise<void> {
-    const result = await this.client.request(`doc/${docId}/update`, 'POST', update)
-
-    if (!result.ok) {
-      throw new Error(`Failed to update doc ${docId}: ${result.status} ${result.statusText}`)
-    }
+    const connection = await this.getDocConnection(docId)
+    return await connection.updateDoc(update)
   }
 
   public async getDocConnection(docId: string): Promise<DocConnection> {

--- a/js-pkg/sdk/src/main.ts
+++ b/js-pkg/sdk/src/main.ts
@@ -5,7 +5,6 @@ export type { DocCreationResult, ClientToken, CheckStoreResult } from './types'
 export { type YSweetErrorPayload, YSweetError } from './error'
 export { encodeClientToken, decodeClientToken } from './encoding'
 
-
 /** Represents an interface to a y-sweet document management endpoint. */
 export class DocumentManager {
   /** Wraps a fetch request with authorization and error handling. */
@@ -104,20 +103,8 @@ export class DocumentManager {
   /**
    * Returns an entire document, represented as a Yjs update byte string.
    *
-   * This can be turned back into a Yjs document as follows:
-   *
-   * ```typescript
-   * import * as Y from 'yjs'
-   *
-   * let update = await manager.getDocAsUpdate(docId)
-   * let doc = new Y.Doc()
-   * doc.transact(() => {
-   *  Y.applyUpdate(doc, update)
-   * })
-   * ```
-   *
-   * @param docId
-   * @returns
+   * @param docId The ID of the document to get.
+   * @returns The document as a Yjs update byte string
    */
   public async getDocAsUpdate(docId: string): Promise<Uint8Array> {
     const result = await this.client.request(`doc/${docId}/as-update`, 'GET')
@@ -132,26 +119,10 @@ export class DocumentManager {
   /**
    * Updates a document with the given Yjs update byte string.
    *
-   * This can be generated from a Yjs document as follows:
-   *
-   * ```typescript
-   * import * as Y from 'yjs'
-   *
-   * let doc = new Y.Doc()
-   * // Modify the document...
-   * let update = Y.encodeStateAsUpdate(doc)
-   * await manager.updateDoc(docId, update)
-   * ```
-   *
-   * @param docId
-   * @param update
+   * @param docId The ID of the document to update.
+   * @param update The Yjs update byte string to apply to the document.
    */
   public async updateDoc(docId: string, update: Uint8Array): Promise<void> {
-    let headers: [string, string][] = [['Content-Type', 'application/octet-stream']]
-    if (this.token) {
-      headers.push(['Authorization', `Bearer ${this.token}`])
-    }
-
     const result = await this.client.request(`doc/${docId}/update`, 'POST', update)
 
     if (!result.ok) {

--- a/js-pkg/sdk/src/main.ts
+++ b/js-pkg/sdk/src/main.ts
@@ -1,4 +1,4 @@
-import { YSweetConnection } from './connection'
+import { DocConnection } from './connection'
 import { YSweetError } from './error'
 import { HttpClient } from './http'
 import type { DocCreationResult, ClientToken, CheckStoreResult } from './types'
@@ -10,9 +10,6 @@ export { encodeClientToken, decodeClientToken } from './encoding'
 export class DocumentManager {
   /** Wraps a fetch request with authorization and error handling. */
   private client: HttpClient
-
-  /** A string that grants the bearer access to the document management API. */
-  private token?: string
 
   /**
    * Create a new {@link DocumentManager}.
@@ -131,9 +128,9 @@ export class DocumentManager {
     }
   }
 
-  public async getConnection(docId: string): Promise<YSweetConnection> {
+  public async getDocConnection(docId: string): Promise<DocConnection> {
     const clientToken = await this.getClientToken(docId)
-    return new YSweetConnection(clientToken)
+    return new DocConnection(clientToken)
   }
 }
 

--- a/tests/src/convert.test.ts
+++ b/tests/src/convert.test.ts
@@ -46,6 +46,7 @@ async function connectToDoc(server: Server, docId: string): Promise<Y.Doc> {
 
 test('can convert an empty doc from an update', async () => {
   const server = new Server({ useAuth: false, server: 'native' })
+  await server.waitForReady()
   const doc = new Y.Doc()
   const docId = Math.random().toString(36).substring(7)
   await convertDoc(doc, docId, server.dataDir)

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -144,52 +144,51 @@ describe.each(CONFIGURATIONS)(
       await connection.updateDoc(Y.encodeStateAsUpdate(doc))
     })
 
+    test('Fetch doc as update', async () => {
+      const docResult = await DOCUMENT_MANANGER.createDoc()
+      const key = await DOCUMENT_MANANGER.getClientToken(docResult)
 
-    // test('Fetch doc as update', async () => {
-    //   const docResult = await DOCUMENT_MANANGER.createDoc()
-    //   const key = await DOCUMENT_MANANGER.getClientToken(docResult)
+      const doc = new Y.Doc()
+      const provider = createYjsProvider(doc, key, {})
 
-    //   const doc = new Y.Doc()
-    //   const provider = createYjsProvider(doc, key, {})
+      let map = doc.getMap('test')
+      map.set('foo', 'bar')
+      map.set('baz', 'qux')
 
-    //   let map = doc.getMap('test')
-    //   map.set('foo', 'bar')
-    //   map.set('baz', 'qux')
+      await waitForProviderSync(provider)
 
-    //   await waitForProviderSync(provider)
+      const update = await DOCUMENT_MANANGER.getDocAsUpdate(docResult.docId)
 
-    //   const update = await DOCUMENT_MANANGER.getDocAsUpdate(docResult.docId)
+      let newDoc = new Y.Doc()
+      newDoc.transact(() => {
+        Y.applyUpdate(newDoc, update)
+      })
 
-    //   let newDoc = new Y.Doc()
-    //   newDoc.transact(() => {
-    //     Y.applyUpdate(newDoc, update)
-    //   })
+      let newMap = newDoc.getMap('test')
+      expect(newMap.get('foo')).toBe('bar')
+      expect(newMap.get('baz')).toBe('qux')
+    })
 
-    //   let newMap = newDoc.getMap('test')
-    //   expect(newMap.get('foo')).toBe('bar')
-    //   expect(newMap.get('baz')).toBe('qux')
-    // })
+    test('Update doc over HTTP POST', async () => {
+      const docResult = await DOCUMENT_MANANGER.createDoc()
 
-    // test('Update doc over HTTP POST', async () => {
-    //   const docResult = await DOCUMENT_MANANGER.createDoc()
+      const doc = new Y.Doc()
 
-    //   const doc = new Y.Doc()
+      let map = doc.getMap('abc123')
+      map.set('123', '456')
 
-    //   let map = doc.getMap('abc123')
-    //   map.set('123', '456')
+      let update = Y.encodeStateAsUpdate(doc)
 
-    //   let update = Y.encodeStateAsUpdate(doc)
+      await DOCUMENT_MANANGER.updateDoc(docResult.docId, update)
 
-    //   await DOCUMENT_MANANGER.updateDoc(docResult.docId, update)
+      const key = await DOCUMENT_MANANGER.getClientToken(docResult)
 
-    //   const key = await DOCUMENT_MANANGER.getClientToken(docResult)
+      const provider = createYjsProvider(doc, key, {})
+      await waitForProviderSync(provider)
 
-    //   const provider = createYjsProvider(doc, key, {})
-    //   await waitForProviderSync(provider)
-
-    //   let newMap = doc.getMap('abc123')
-    //   expect(newMap.get('123')).toBe('456')
-    // })
+      let newMap = doc.getMap('abc123')
+      expect(newMap.get('123')).toBe('456')
+    })
 
     test('Create a doc by specifying a name', async () => {
       const docResult = await DOCUMENT_MANANGER.createDoc('mydoc123')

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -105,7 +105,7 @@ describe.each(CONFIGURATIONS)(
       // When running Cloudflare's workerd locally, sometimes the call following
       // the 404 will fail with a 500.
       // Not sure why, but this is a workaround.
-      await DOCUMENT_MANANGER.createDoc().catch(() => { })
+      await DOCUMENT_MANANGER.createDoc().catch(() => {})
     })
 
     test('Connection token should have baseUrl', async () => {

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -133,51 +133,63 @@ describe.each(CONFIGURATIONS)(
       })
     })
 
-    test('Fetch doc as update', async () => {
+    test('Update doc', async () => {
       const docResult = await DOCUMENT_MANANGER.createDoc()
-      const key = await DOCUMENT_MANANGER.getClientToken(docResult)
+      const connection = await DOCUMENT_MANANGER.getDocConnection(docResult.docId)
 
       const doc = new Y.Doc()
-      const provider = createYjsProvider(doc, key, {})
+      const text = doc.getText('test')
+      text.insert(0, 'Hello, world!')
 
-      let map = doc.getMap('test')
-      map.set('foo', 'bar')
-      map.set('baz', 'qux')
-
-      await waitForProviderSync(provider)
-
-      const update = await DOCUMENT_MANANGER.getDocAsUpdate(docResult.docId)
-
-      let newDoc = new Y.Doc()
-      newDoc.transact(() => {
-        Y.applyUpdate(newDoc, update)
-      })
-
-      let newMap = newDoc.getMap('test')
-      expect(newMap.get('foo')).toBe('bar')
-      expect(newMap.get('baz')).toBe('qux')
+      await connection.updateDoc(Y.encodeStateAsUpdate(doc))
     })
 
-    test('Update doc over HTTP POST', async () => {
-      const docResult = await DOCUMENT_MANANGER.createDoc()
 
-      const doc = new Y.Doc()
+    // test('Fetch doc as update', async () => {
+    //   const docResult = await DOCUMENT_MANANGER.createDoc()
+    //   const key = await DOCUMENT_MANANGER.getClientToken(docResult)
 
-      let map = doc.getMap('abc123')
-      map.set('123', '456')
+    //   const doc = new Y.Doc()
+    //   const provider = createYjsProvider(doc, key, {})
 
-      let update = Y.encodeStateAsUpdate(doc)
+    //   let map = doc.getMap('test')
+    //   map.set('foo', 'bar')
+    //   map.set('baz', 'qux')
 
-      await DOCUMENT_MANANGER.updateDoc(docResult.docId, update)
+    //   await waitForProviderSync(provider)
 
-      const key = await DOCUMENT_MANANGER.getClientToken(docResult)
+    //   const update = await DOCUMENT_MANANGER.getDocAsUpdate(docResult.docId)
 
-      const provider = createYjsProvider(doc, key, {})
-      await waitForProviderSync(provider)
+    //   let newDoc = new Y.Doc()
+    //   newDoc.transact(() => {
+    //     Y.applyUpdate(newDoc, update)
+    //   })
 
-      let newMap = doc.getMap('abc123')
-      expect(newMap.get('123')).toBe('456')
-    })
+    //   let newMap = newDoc.getMap('test')
+    //   expect(newMap.get('foo')).toBe('bar')
+    //   expect(newMap.get('baz')).toBe('qux')
+    // })
+
+    // test('Update doc over HTTP POST', async () => {
+    //   const docResult = await DOCUMENT_MANANGER.createDoc()
+
+    //   const doc = new Y.Doc()
+
+    //   let map = doc.getMap('abc123')
+    //   map.set('123', '456')
+
+    //   let update = Y.encodeStateAsUpdate(doc)
+
+    //   await DOCUMENT_MANANGER.updateDoc(docResult.docId, update)
+
+    //   const key = await DOCUMENT_MANANGER.getClientToken(docResult)
+
+    //   const provider = createYjsProvider(doc, key, {})
+    //   await waitForProviderSync(provider)
+
+    //   let newMap = doc.getMap('abc123')
+    //   expect(newMap.get('123')).toBe('456')
+    // })
 
     test('Create a doc by specifying a name', async () => {
       const docResult = await DOCUMENT_MANANGER.createDoc('mydoc123')

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -105,7 +105,7 @@ describe.each(CONFIGURATIONS)(
       // When running Cloudflare's workerd locally, sometimes the call following
       // the 404 will fail with a 500.
       // Not sure why, but this is a workaround.
-      await DOCUMENT_MANANGER.createDoc().catch(() => {})
+      await DOCUMENT_MANANGER.createDoc().catch(() => { })
     })
 
     test('Connection token should have baseUrl', async () => {
@@ -133,7 +133,7 @@ describe.each(CONFIGURATIONS)(
       })
     })
 
-    test('Update doc', async () => {
+    test('Update doc and fetch as update', async () => {
       const docResult = await DOCUMENT_MANANGER.createDoc()
       const connection = await DOCUMENT_MANANGER.getDocConnection(docResult.docId)
 
@@ -142,6 +142,17 @@ describe.each(CONFIGURATIONS)(
       text.insert(0, 'Hello, world!')
 
       await connection.updateDoc(Y.encodeStateAsUpdate(doc))
+
+      const update = await connection.getAsUpdate()
+      expect(update).toBeDefined()
+
+      const newDoc = new Y.Doc()
+      newDoc.transact(() => {
+        Y.applyUpdate(newDoc, update)
+      })
+
+      const newText = newDoc.getText('test')
+      expect(newText.toString()).toBe('Hello, world!')
     })
 
     test('Fetch doc as update', async () => {

--- a/tests/src/server.ts
+++ b/tests/src/server.ts
@@ -53,7 +53,7 @@ export class Server {
 
     mkdirSync(outFilePath, { recursive: true })
 
-    this.outFileBase = join(outFilePath, configToString(configuration))
+    this.outFileBase = join(outFilePath, configToString(configuration) + '-' + this.port)
     mkdirSync(this.outFileBase, { recursive: true })
     this.dataDir = join(this.outFileBase, 'data')
     mkdirSync(this.dataDir, { recursive: true })


### PR DESCRIPTION
This PR:

- Adds a `DocConnection` class in the SDK, which wraps a `ClientToken` and can be used to make REST requests to a document.
- Refactors HTTP-level concerns into an `HttpClient` class
- Modifies the `DocumentManager.getDocAsUpdate` and `.updateDoc` methods to work via a `DocConnection`. This ensures that in a multi-node environment, application data goes directly to the relevant y-sweet server instead of traveling through the y-sweet API server.
- Adds a test.

In the process, it modifies how authorization works in Y-Sweet so that a server token can be used to access any document.

Design doc: https://docs.google.com/document/d/10O4-i9sxUL5-bWjIYqgxbStJGqNCVLfP411J9x-fTFM/edit