### PR TITLE
Improve Python API

### DIFF
--- a/js-pkg/sdk/src/connection.ts
+++ b/js-pkg/sdk/src/connection.ts
@@ -6,7 +6,9 @@ export class DocConnection {
   private docId: string
 
   constructor(clientToken: ClientToken) {
-    this.client = new HttpClient(clientToken.baseUrl, clientToken.token ?? null)
+    // Strip trailing slash from baseUrl
+    let baseUrl = clientToken.baseUrl.replace(/\/$/, '')
+    this.client = new HttpClient(baseUrl, clientToken.token ?? null)
     this.docId = clientToken.docId
   }
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,7 +14,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["requests~=2.32.2"]
+dependencies = [
+    "requests~=2.32.2",
+    "pycrdt~=0.9.11",
+]
 
 [project.urls]
 Homepage = "https://github.com/jamsocket/y-sweet"
@@ -23,7 +26,6 @@ Homepage = "https://github.com/jamsocket/y-sweet"
 dev = [
     "pytest~=8.3.3",
     "ruff~=0.6.5",
-    "pycrdt~=0.9.11",
 ]
 
 [tool.setuptools]

--- a/python/src/y_sweet_sdk/connection.py
+++ b/python/src/y_sweet_sdk/connection.py
@@ -1,10 +1,12 @@
 import requests
 from typing import Dict, Optional
 
+from .update import UpdateContext
+
 
 class DocConnection:
     def __init__(self, client_token: Dict[str, str]):
-        self.base_url = client_token["baseUrl"]
+        self.base_url = client_token["baseUrl"].rstrip("/")
         self.token = client_token.get("token")
         self.doc_id = client_token["docId"]
         self.headers = {"Authorization": f"Bearer {self.token}"} if self.token else {}
@@ -35,3 +37,6 @@ class DocConnection:
             update (bytes): The Yjs update as bytes.
         """
         self._do_request("update", method="POST", data=update)
+
+    def for_update(self) -> UpdateContext:
+        return UpdateContext(self)

--- a/python/src/y_sweet_sdk/update.py
+++ b/python/src/y_sweet_sdk/update.py
@@ -9,7 +9,7 @@ import pycrdt
 
 class UpdateContext:
     """
-    Context manager for retreiving a Yjs document from a connection, applying updates
+    Context manager for retrieving a Yjs document from a connection, applying updates
     to it, and then sending the updates to the server.
 
     Usage:

--- a/python/src/y_sweet_sdk/update.py
+++ b/python/src/y_sweet_sdk/update.py
@@ -1,0 +1,46 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Avoid circular import
+    from .connection import DocConnection
+
+import pycrdt
+
+
+class UpdateContext:
+    """
+    Context manager for retreiving a Yjs document from a connection, applying updates
+    to it, and then sending the updates to the server.
+
+    Usage:
+
+    ```python
+    import pycrdt
+
+    dm = DocumentManager(CONNECTION_STRING)
+    conn = dm.get_connection("my-doc")
+
+    with conn.for_update() as doc:
+        my_map = doc.get("my-map", pycrdt.Map)
+        my_map['foo'] = 'bar'
+    ```
+    """
+
+    def __init__(self, conn: "DocConnection"):
+        self.conn = conn
+        self.doc = None
+        self.state = None
+
+    def __enter__(self) -> pycrdt.Doc:
+        update = self.conn.get_as_update()
+        self.doc = pycrdt.Doc()
+        self.doc.apply_update(update)
+        self.state = self.doc.get_state()
+        return self.doc
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type is not None:
+            return False
+
+        update = self.doc.get_update(self.state)
+        self.conn.update_doc(update)


### PR DESCRIPTION
- In the Python and JS API, remove trailing slashes on `baseUrl` (ideally we should just be consistent here but this was easier for now)
- Introduces a new API that works with Python's `with` statement. It gives you a way to:
  - Get the latest doc from the server
  - Make updates to that doc
  - Save the changes back to the server, sending only what has changed

```python
import pycrdt
dm = DocumentManager(CONNECTION_STRING)
conn = dm.get_connection("my-doc")
with conn.for_update() as doc:
    my_map = doc.get("my-map", pycrdt.Map)
    my_map['foo'] = 'bar'
```