### PR TITLE
Disable doc garbage collection when running in `serve-doc` mode.

### DIFF
--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -179,6 +179,7 @@ async fn main() -> Result<()> {
                 auth,
                 url_prefix.clone(),
                 token.clone(),
+                true,
             )
             .await?;
 
@@ -262,6 +263,7 @@ async fn main() -> Result<()> {
                 None, // No authenticator
                 None, // No URL prefix
                 cancellation_token.clone(),
+                false,
             )
             .await?;
 

--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -37,7 +37,7 @@ enum ServSubcommand {
         #[clap(env = "Y_SWEET_STORE")]
         store: Option<String>,
 
-        #[clap(long, default_value = "8080", env = "Y_SWEET_PORT")]
+        #[clap(long, default_value = "8080", env = "PORT")]
         port: u16,
         #[clap(long, env = "Y_SWEET_HOST")]
         host: Option<IpAddr>,
@@ -73,7 +73,7 @@ enum ServSubcommand {
     Version,
 
     ServeDoc {
-        #[clap(long, default_value = "8080", env = "Y_SWEET_PORT")]
+        #[clap(long, default_value = "8080", env = "PORT")]
         port: u16,
 
         #[clap(long, env = "Y_SWEET_HOST")]

--- a/js-pkg/sdk/src/main.ts
+++ b/js-pkg/sdk/src/main.ts
@@ -1,5 +1,5 @@
 import { DocConnection } from './connection'
-import { YSweetError } from './error'
+export { DocConnection } from './connection'
 import { HttpClient } from './http'
 import type { DocCreationResult, ClientToken, CheckStoreResult } from './types'
 export type { DocCreationResult, ClientToken, CheckStoreResult } from './types'

--- a/tests/src/doc-server.test.ts
+++ b/tests/src/doc-server.test.ts
@@ -5,6 +5,8 @@ import { ClientToken, DocConnection } from '@y-sweet/sdk'
 
 export const CRATE_BASE = join(dirname(__filename), '..', '..', 'crates')
 
+const TEN_MINUTES_IN_MS = 10 * 60 * 1_000
+
 let SERVER: DocServer
 
 class DocServer {
@@ -72,7 +74,7 @@ beforeAll(async () => {
   SERVER = new DocServer()
 
   await SERVER.waitForReady()
-}, 10_000)
+}, TEN_MINUTES_IN_MS)
 
 afterAll(() => {
   SERVER.cleanup()

--- a/tests/src/doc-server.test.ts
+++ b/tests/src/doc-server.test.ts
@@ -3,7 +3,7 @@ import { ChildProcess, spawn } from 'child_process'
 import { dirname, join } from 'path'
 import { ClientToken, DocConnection } from '@y-sweet/sdk'
 
-export const CRATE_BASE = join(dirname(__filename), '..', '..', 'crates')
+const CRATE_BASE = join(dirname(__filename), '..', '..', 'crates')
 
 const TEN_MINUTES_IN_MS = 10 * 60 * 1_000
 

--- a/tests/src/doc-server.test.ts
+++ b/tests/src/doc-server.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, test } from 'vitest'
+import { ChildProcess, spawn } from 'child_process'
+import { dirname, join } from 'path'
+import { ClientToken, DocConnection } from '@y-sweet/sdk'
+
+export const CRATE_BASE = join(dirname(__filename), '..', '..', 'crates')
+
+let SERVER: DocServer
+
+class DocServer {
+  private port: number
+  private process: ChildProcess
+  private reject?: (reason?: any) => void
+
+  constructor() {
+    this.port = Math.floor(Math.random() * 10000) + 10000
+
+    this.process = spawn('cargo run -- serve-doc', {
+      cwd: CRATE_BASE,
+      shell: true,
+      stdio: 'inherit',
+      env: {
+        SESSION_BACKEND_KEY: 'mydoc',
+        PORT: this.port.toString(),
+        ...process.env,
+      },
+    })
+
+    this.process.on('error', (error) => {
+      console.error('Error starting doc server', error)
+      this.reject?.(error)
+      process.exit(1)
+    })
+
+    this.process.on('close', (code) => {
+      this.reject?.(new Error(`Doc server exited with code ${code}`))
+    })
+  }
+
+  async waitForReady(): Promise<void> {
+    const attempts = 300
+    for (let i = 0; i < attempts; i++) {
+      try {
+        await fetch(`http://127.0.0.1:${this.port}`)
+        console.log('Server started.')
+        return
+      } catch (e) {
+        await new Promise((resolve, reject) => {
+          this.reject = reject
+          setTimeout(resolve, 1_000)
+        })
+      }
+    }
+    throw new Error('Server failed to start')
+  }
+
+  connection(): DocConnection {
+    let token: ClientToken = {
+      baseUrl: `http://127.0.0.1:${this.port}`,
+      docId: 'mydoc',
+      url: '==unused==',
+    }
+    return new DocConnection(token)
+  }
+
+  cleanup() {
+    this.process.kill()
+  }
+}
+
+beforeAll(async () => {
+  SERVER = new DocServer()
+
+  await SERVER.waitForReady()
+}, 10_000)
+
+afterAll(() => {
+  SERVER.cleanup()
+})
+
+test('get doc as update', async () => {
+  let connection = SERVER.connection()
+
+  await connection.getAsUpdate()
+})
+
+test('get doc as update after delay', async () => {
+  let connection = SERVER.connection()
+
+  await new Promise((resolve) => setTimeout(resolve, 24_000))
+
+  await connection.getAsUpdate()
+}, 30_000)

--- a/tests/src/server.ts
+++ b/tests/src/server.ts
@@ -1,6 +1,5 @@
 import { ChildProcess, execSync, spawn } from 'child_process'
 import { rmSync, mkdirSync } from 'fs'
-import { tmpdir } from 'os'
 import { dirname, join } from 'path'
 
 export type ServerType = 'native' | 'worker'


### PR DESCRIPTION
When running with `serve-doc`, if there is no active connection, the doc will be garbage collected and then accessing it will not work. This prevents the doc from being garbage collected in `serve-doc` mode.

This also renames the `Y_SWEET_PORT` env var to `PORT`, which is used by convention by most HTTP container hosts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Standardized environment variable usage for port configuration across the application.
	- Introduced a new option for enabling or disabling document garbage collection in the server.
	- Added a testing framework for the document server, ensuring robust lifecycle management during tests.

- **Bug Fixes**
	- Adjusted logic for document garbage collection based on new configuration.

- **Documentation**
	- Updated export statements for improved clarity in module interfaces.

- **Tests**
	- Implemented new test cases for the document server's functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->