### PR TITLE
Fix y-sweet path issue

### DIFF
--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -274,10 +274,6 @@ async fn main() -> Result<()> {
                         None
                     }
                 } else {
-                    if env::var("STORAGE_PREFIX").is_ok() {
-                        anyhow::bail!("If STORAGE_PREFIX is set, STORAGE_BUCKET must also be set.");
-                    }
-
                     None
                 };
 
@@ -287,6 +283,10 @@ async fn main() -> Result<()> {
                 store.init().await?;
                 Some(store)
             } else {
+                if env::var("STORAGE_PREFIX").is_ok() {
+                    anyhow::bail!("If STORAGE_PREFIX is set, STORAGE_BUCKET must also be set.");
+                }
+
                 None
             };
 

--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -274,6 +274,10 @@ async fn main() -> Result<()> {
                         None
                     }
                 } else {
+                    if env::var("STORAGE_PREFIX").is_ok() {
+                        anyhow::bail!("If STORAGE_PREFIX is set, STORAGE_BUCKET must also be set.");
+                    }
+
                     None
                 };
 


### PR DESCRIPTION
When a y-sweet service is started in a session backend environment (i.e. `serve-doc`), it expects to receive the document ID as `SESSION_BACKEND_KEY`.

When an S3 bucket is attached for storage, an environment variable `STORAGE_PREFIX` is also generated by combining some configured prefix with the doc ID.

A problem arises because y-sweet already expects to concatenate the doc ID when doing a lookup. The result is that we end up with the document ID repeated in the path.

We would still like to respect `STORAGE_PREFIX` if it is provided, but we want to avoid duplicating the doc ID. This PR:
- Ensures that the last /-delimited component of the `STORAGE_PREFIX` is the doc ID, unless `STORAGE_PREFIX` is unset or empty
- Chops the doc ID off and constructs a new `STORAGE_PREFIX`.

Also, we no longer require `STORAGE_PREFIX` (since it is allowed to be empty), but we do not allow `STORAGE_PREFIX` to be set unless `STORAGE_BUCKET` also is.

I'd like to chop this code up more so that we can unit test it better, but for now I've tested locally and it solves the issue I was having.