### PR TITLE
Fix ctrl+c shutdown for `serve-doc`

### DIFF
--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -163,7 +163,6 @@ impl Server {
                         doc_id.clone(),
                         checkpoint_freq,
                         cancellation_token,
-                        self.cancellation_token.clone(),
                     )
                     .instrument(span!(Level::INFO, "gc_loop", doc_id=?doc_id)),
                 );
@@ -178,7 +177,6 @@ impl Server {
         docs: Arc<DashMap<String, DocWithSyncKv>>,
         doc_id: String,
         checkpoint_freq: Duration,
-        persistence_cancellation_token: CancellationToken,
         cancellation_token: CancellationToken,
     ) {
         let mut checkpoints_without_refs = 0;
@@ -210,7 +208,6 @@ impl Server {
                 }
             };
         }
-        persistence_cancellation_token.cancel();
         tracing::info!("Exiting gc_loop");
     }
 

--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -142,7 +142,7 @@ impl Server {
             let sync_kv = dwskv.sync_kv();
             let checkpoint_freq = self.checkpoint_freq;
             let doc_id = doc_id.to_string();
-            let persistence_cancellation_token = CancellationToken::new();
+            let cancellation_token = self.cancellation_token.clone();
 
             // Spawn a task to save the document to the store when it changes.
             self.doc_worker_tracker.spawn(
@@ -151,7 +151,7 @@ impl Server {
                     sync_kv,
                     checkpoint_freq,
                     doc_id.clone(),
-                    persistence_cancellation_token.clone(),
+                    cancellation_token.clone(),
                 )
                 .instrument(span!(Level::INFO, "save_loop", doc_id=?doc_id)),
             );
@@ -162,7 +162,7 @@ impl Server {
                         self.docs.clone(),
                         doc_id.clone(),
                         checkpoint_freq,
-                        persistence_cancellation_token,
+                        cancellation_token,
                         self.cancellation_token.clone(),
                     )
                     .instrument(span!(Level::INFO, "gc_loop", doc_id=?doc_id)),


### PR DESCRIPTION
When the ctrl+c signal (SIGINT on unix) is received, we fire off a [`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html), which:
- gracefully shuts down the server process
- shuts down the GC task, which triggers:
  - shuts down persistence task (which waits until every dirty doc is persisted to return)

The mechanism for the GC process triggering the shut down of the persistence task is the `persistence_cancellation_token` which is fired when the GC task completes. However, in `serve-doc`, we only care about one doc so we don't GC inactive docs. This means the `persistence_cancellation_token` never fires in `serve-doc` mode.

The fix is to simplify things: one `cancellation_token` is responsible for all three graceful shutdowns (server, GC task, and persistence task). When we cancel the GC task it simply breaks out of the loop, so there is no code in the GC task that must complete before we shut down the persistence task. (@rbtying please correct me if I'm missing something!)