### PR TITLE
Add validity time option to the API (DIS-2749)

### DIFF
--- a/crates/y-sweet-core/src/api_types.rs
+++ b/crates/y-sweet-core/src/api_types.rs
@@ -34,7 +34,7 @@ pub struct AuthDocRequest {
     pub user_id: Option<String>,
     #[serde(default)]
     pub metadata: HashMap<String, Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "validForSeconds")]
     pub valid_for_seconds: Option<u64>,
 }
 

--- a/crates/y-sweet-core/src/api_types.rs
+++ b/crates/y-sweet-core/src/api_types.rs
@@ -34,6 +34,19 @@ pub struct AuthDocRequest {
     pub user_id: Option<String>,
     #[serde(default)]
     pub metadata: HashMap<String, Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_for_seconds: Option<u64>,
+}
+
+impl Default for AuthDocRequest {
+    fn default() -> Self {
+        Self {
+            authorization: Authorization::Full,
+            user_id: None,
+            metadata: HashMap::new(),
+            valid_for_seconds: None,
+        }
+    }
 }
 
 #[derive(Serialize)]

--- a/crates/y-sweet-core/src/auth.rs
+++ b/crates/y-sweet-core/src/auth.rs
@@ -6,7 +6,22 @@ use sha2::{Digest, Sha256};
 use std::fmt::Display;
 use thiserror::Error;
 
-const EXPIRATION_MILLIS: u64 = 1000 * 60 * 60; // 60 minutes
+pub const DEFAULT_EXPIRATION_MILLIS: u64 = 1000 * 60 * 60; // 60 minutes
+
+/// This newtype is introduced to distinguish between a u64 meant to represent the current time
+/// (currently passed as a raw u64), and a u64 meant to represent an expiration time.
+/// We introduce this to intentonally break callers to `gen_doc_token` that do not explicitly
+/// update to pass an expiration time, so that calls that use the old signature to pass a current
+/// time do not compile.
+/// Unit is milliseconds since Jan 1, 1970.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ExpirationTimeEpochMillis(pub u64);
+
+impl ExpirationTimeEpochMillis {
+    pub fn max() -> Self {
+        Self(u64::MAX)
+    }
+}
 
 /// This is a custom base64 encoder that is equivalent to BASE64URL_NOPAD for encoding,
 /// but is tolerant when decoding of the “standard” alphabet and also of padding.
@@ -84,7 +99,7 @@ pub enum Permission {
 #[derive(Serialize, Deserialize)]
 pub struct Payload {
     pub payload: Permission,
-    pub expiration_millis: Option<u64>,
+    pub expiration_millis: Option<ExpirationTimeEpochMillis>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -141,7 +156,10 @@ impl Payload {
         }
     }
 
-    pub fn new_with_expiration(payload: Permission, expiration_millis: u64) -> Self {
+    pub fn new_with_expiration(
+        payload: Permission,
+        expiration_millis: ExpirationTimeEpochMillis,
+    ) -> Self {
         Self {
             payload,
             expiration_millis: Some(expiration_millis),
@@ -256,7 +274,13 @@ impl Authenticator {
 
         if expected_token != auth_req.token {
             Err(AuthError::InvalidSignature)
-        } else if auth_req.payload.expiration_millis.unwrap_or(u64::MAX) < current_time {
+        } else if auth_req
+            .payload
+            .expiration_millis
+            .unwrap_or(ExpirationTimeEpochMillis::max())
+            .0
+            < current_time
+        {
             Err(AuthError::Expired)
         } else {
             Ok(auth_req.payload)
@@ -289,12 +313,13 @@ impl Authenticator {
         b64_encode(&self.private_key)
     }
 
-    pub fn gen_doc_token(&self, doc_id: &str, current_time_epoch_millis: u64) -> String {
-        let expiration_time_epoch_millis = current_time_epoch_millis + EXPIRATION_MILLIS;
-        let payload = Payload::new_with_expiration(
-            Permission::Doc(doc_id.to_string()),
-            expiration_time_epoch_millis,
-        );
+    pub fn gen_doc_token(
+        &self,
+        doc_id: &str,
+        expiration_time: ExpirationTimeEpochMillis,
+    ) -> String {
+        let payload =
+            Payload::new_with_expiration(Permission::Doc(doc_id.to_string()), expiration_time);
         self.sign(payload)
     }
 
@@ -361,10 +386,10 @@ mod tests {
     #[test]
     fn test_simple_auth() {
         let authenticator = Authenticator::gen_key().unwrap();
-        let token = authenticator.gen_doc_token("doc123", 0);
+        let token = authenticator.gen_doc_token("doc123", ExpirationTimeEpochMillis(0));
         assert_eq!(authenticator.verify_doc_token(&token, "doc123", 0), Ok(()));
         assert_eq!(
-            authenticator.verify_doc_token(&token, "doc123", EXPIRATION_MILLIS + 1),
+            authenticator.verify_doc_token(&token, "doc123", DEFAULT_EXPIRATION_MILLIS + 1),
             Err(AuthError::Expired)
         );
         assert_eq!(
@@ -378,7 +403,7 @@ mod tests {
         let authenticator = Authenticator::gen_key()
             .unwrap()
             .with_key_id("myKeyId".try_into().unwrap());
-        let token = authenticator.gen_doc_token("doc123", 0);
+        let token = authenticator.gen_doc_token("doc123", ExpirationTimeEpochMillis(0));
         assert!(
             token.starts_with("myKeyId."),
             "Token {} does not start with myKeyId.",
@@ -413,7 +438,7 @@ mod tests {
         let authenticator = Authenticator::gen_key()
             .unwrap()
             .with_key_id("myKeyId".try_into().unwrap());
-        let token = authenticator.gen_doc_token("doc123", 0);
+        let token = authenticator.gen_doc_token("doc123", ExpirationTimeEpochMillis(0));
         let token = token.replace("myKeyId.", "aDifferentKeyId.");
         assert!(token.starts_with("aDifferentKeyId."));
         assert_eq!(
@@ -427,7 +452,7 @@ mod tests {
         let authenticator = Authenticator::gen_key()
             .unwrap()
             .with_key_id("myKeyId".try_into().unwrap());
-        let token = authenticator.gen_doc_token("doc123", 0);
+        let token = authenticator.gen_doc_token("doc123", ExpirationTimeEpochMillis(0));
         let token = token.replace("myKeyId.", "");
         assert_eq!(
             authenticator.verify_doc_token(&token, "doc123", 0),
@@ -438,7 +463,7 @@ mod tests {
     #[test]
     fn test_unexpected_key_id() {
         let authenticator = Authenticator::gen_key().unwrap();
-        let token = authenticator.gen_doc_token("doc123", 0);
+        let token = authenticator.gen_doc_token("doc123", ExpirationTimeEpochMillis(0));
         let token = format!("unexpectedKeyId.{}", token);
         assert_eq!(
             authenticator.verify_doc_token(&token, "doc123", 0),

--- a/crates/y-sweet-core/src/auth.rs
+++ b/crates/y-sweet-core/src/auth.rs
@@ -6,7 +6,7 @@ use sha2::{Digest, Sha256};
 use std::fmt::Display;
 use thiserror::Error;
 
-pub const DEFAULT_EXPIRATION_MILLIS: u64 = 1000 * 60 * 60; // 60 minutes
+pub const DEFAULT_EXPIRATION_SECONDS: u64 = 60 * 60; // 60 minutes
 
 /// This newtype is introduced to distinguish between a u64 meant to represent the current time
 /// (currently passed as a raw u64), and a u64 meant to represent an expiration time.
@@ -389,7 +389,7 @@ mod tests {
         let token = authenticator.gen_doc_token("doc123", ExpirationTimeEpochMillis(0));
         assert_eq!(authenticator.verify_doc_token(&token, "doc123", 0), Ok(()));
         assert_eq!(
-            authenticator.verify_doc_token(&token, "doc123", DEFAULT_EXPIRATION_MILLIS + 1),
+            authenticator.verify_doc_token(&token, "doc123", DEFAULT_EXPIRATION_SECONDS + 1),
             Err(AuthError::Expired)
         );
         assert_eq!(

--- a/crates/y-sweet-worker/src/lib.rs
+++ b/crates/y-sweet-worker/src/lib.rs
@@ -11,7 +11,7 @@ use y_sweet_core::{
     api_types::{
         validate_doc_name, AuthDocRequest, ClientToken, DocCreationRequest, NewDocResponse,
     },
-    auth::{Authenticator, ExpirationTimeEpochMillis, DEFAULT_EXPIRATION_MILLIS},
+    auth::{Authenticator, ExpirationTimeEpochMillis, DEFAULT_EXPIRATION_SECONDS},
     doc_sync::DocWithSyncKv,
     store::StoreError,
 };
@@ -210,7 +210,7 @@ async fn auth_doc(
     // Note: to preserve the existing behavior, we default to an empty request.
     let body = req.json::<AuthDocRequest>().await.unwrap_or_default();
 
-    let valid_time_seconds = body.valid_for_seconds.unwrap_or(DEFAULT_EXPIRATION_MILLIS);
+    let valid_time_seconds = body.valid_for_seconds.unwrap_or(DEFAULT_EXPIRATION_SECONDS);
     let expiration_time =
         ExpirationTimeEpochMillis(get_time_millis_since_epoch() + valid_time_seconds * 1000);
 

--- a/crates/y-sweet-worker/src/lib.rs
+++ b/crates/y-sweet-worker/src/lib.rs
@@ -208,7 +208,10 @@ async fn auth_doc(
     }
 
     // Note: to preserve the existing behavior, we default to an empty request.
-    let body = req.json::<AuthDocRequest>().await.unwrap_or_default();
+    let body = req
+        .json::<AuthDocRequest>()
+        .await
+        .map_err(|_| Error::BadRequest)?;
 
     let valid_time_seconds = body.valid_for_seconds.unwrap_or(DEFAULT_EXPIRATION_SECONDS);
     let expiration_time =

--- a/crates/y-sweet-worker/src/lib.rs
+++ b/crates/y-sweet-worker/src/lib.rs
@@ -8,8 +8,10 @@ use std::collections::HashMap;
 use worker::{event, Env};
 use worker::{Date, Method, Request, Response, ResponseBody, Result, RouteContext, Router, Url};
 use y_sweet_core::{
-    api_types::{validate_doc_name, ClientToken, DocCreationRequest, NewDocResponse},
-    auth::Authenticator,
+    api_types::{
+        validate_doc_name, AuthDocRequest, ClientToken, DocCreationRequest, NewDocResponse,
+    },
+    auth::{Authenticator, ExpirationTimeEpochMillis, DEFAULT_EXPIRATION_MILLIS},
     doc_sync::DocWithSyncKv,
     store::StoreError,
 };
@@ -189,7 +191,7 @@ async fn auth_doc_handler(req: Request, ctx: RouteContext<ServerContext>) -> Res
 }
 
 async fn auth_doc(
-    req: Request,
+    mut req: Request,
     mut ctx: RouteContext<ServerContext>,
 ) -> std::result::Result<ClientToken, Error> {
     check_server_token(&req, ctx.data.auth()?)?;
@@ -205,10 +207,16 @@ async fn auth_doc(
         return Err(Error::NoSuchDocument);
     }
 
+    // Note: to preserve the existing behavior, we default to an empty request.
+    let body = req.json::<AuthDocRequest>().await.unwrap_or_default();
+
+    let valid_time = body.valid_for_seconds.unwrap_or(DEFAULT_EXPIRATION_MILLIS);
+    let expiration_time = ExpirationTimeEpochMillis(get_time_millis_since_epoch() + valid_time);
+
     let token = ctx
         .data
         .auth()?
-        .map(|auth| auth.gen_doc_token(&doc_id, get_time_millis_since_epoch()));
+        .map(|auth| auth.gen_doc_token(&doc_id, expiration_time));
 
     let url = if let Some(url_prefix) = &ctx.data.config.url_prefix {
         let mut parsed = Url::parse(url_prefix).map_err(|_| Error::ConfigurationError {

--- a/crates/y-sweet-worker/src/lib.rs
+++ b/crates/y-sweet-worker/src/lib.rs
@@ -210,8 +210,9 @@ async fn auth_doc(
     // Note: to preserve the existing behavior, we default to an empty request.
     let body = req.json::<AuthDocRequest>().await.unwrap_or_default();
 
-    let valid_time = body.valid_for_seconds.unwrap_or(DEFAULT_EXPIRATION_MILLIS);
-    let expiration_time = ExpirationTimeEpochMillis(get_time_millis_since_epoch() + valid_time);
+    let valid_time_seconds = body.valid_for_seconds.unwrap_or(DEFAULT_EXPIRATION_MILLIS);
+    let expiration_time =
+        ExpirationTimeEpochMillis(get_time_millis_since_epoch() + valid_time_seconds * 1000);
 
     let token = ctx
         .data

--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -652,6 +652,7 @@ async fn auth_doc(
     }
 
     let valid_for_seconds = body.valid_for_seconds.unwrap_or(DEFAULT_EXPIRATION_MILLIS);
+    println!("valid_for_seconds {}", valid_for_seconds);
     let expiration_time =
         ExpirationTimeEpochMillis(current_time_epoch_millis() + valid_for_seconds * 1000);
 

--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -32,7 +32,7 @@ use y_sweet_core::{
     api_types::{
         validate_doc_name, AuthDocRequest, ClientToken, DocCreationRequest, NewDocResponse,
     },
-    auth::{Authenticator, ExpirationTimeEpochMillis, DEFAULT_EXPIRATION_MILLIS},
+    auth::{Authenticator, ExpirationTimeEpochMillis, DEFAULT_EXPIRATION_SECONDS},
     doc_connection::DocConnection,
     doc_sync::DocWithSyncKv,
     store::Store,
@@ -651,8 +651,7 @@ async fn auth_doc(
         Err((StatusCode::NOT_FOUND, anyhow!("Doc {} not found", doc_id)))?;
     }
 
-    let valid_for_seconds = body.valid_for_seconds.unwrap_or(DEFAULT_EXPIRATION_MILLIS);
-    println!("valid_for_seconds {}", valid_for_seconds);
+    let valid_for_seconds = body.valid_for_seconds.unwrap_or(DEFAULT_EXPIRATION_SECONDS);
     let expiration_time =
         ExpirationTimeEpochMillis(current_time_epoch_millis() + valid_for_seconds * 1000);
 

--- a/js-pkg/sdk/src/main.ts
+++ b/js-pkg/sdk/src/main.ts
@@ -72,7 +72,10 @@ export class DocumentManager {
    * @param docId The ID of the document to get a token for.
    * @returns A {@link ClientToken} object containing the URL and token needed to connect to the document.
    */
-  public async getClientToken(docId: string | DocCreationResult, authDocRequest?: AuthDocRequest): Promise<ClientToken> {
+  public async getClientToken(
+    docId: string | DocCreationResult,
+    authDocRequest?: AuthDocRequest,
+  ): Promise<ClientToken> {
     if (typeof docId !== 'string') {
       docId = docId.docId
     }
@@ -93,7 +96,10 @@ export class DocumentManager {
    * @param docId The ID of the document to get or create. If not provided, a new document with a random ID will be created.
    * @returns A {@link ClientToken} object containing the URL and token needed to connect to the document.
    */
-  public async getOrCreateDocAndToken(docId?: string, authDocRequest?: AuthDocRequest): Promise<ClientToken> {
+  public async getOrCreateDocAndToken(
+    docId?: string,
+    authDocRequest?: AuthDocRequest,
+  ): Promise<ClientToken> {
     const result = await this.createDoc(docId)
     return await this.getClientToken(result, authDocRequest)
   }
@@ -120,7 +126,10 @@ export class DocumentManager {
     return await connection.updateDoc(update)
   }
 
-  public async getDocConnection(docId: string | DocCreationResult, authDocRequest?: AuthDocRequest): Promise<DocConnection> {
+  public async getDocConnection(
+    docId: string | DocCreationResult,
+    authDocRequest?: AuthDocRequest,
+  ): Promise<DocConnection> {
     const clientToken = await this.getClientToken(docId, authDocRequest)
     return new DocConnection(clientToken)
   }

--- a/js-pkg/sdk/src/main.ts
+++ b/js-pkg/sdk/src/main.ts
@@ -70,6 +70,7 @@ export class DocumentManager {
    * client.
    *
    * @param docId The ID of the document to get a token for.
+   * @param authDocRequest An optional {@link AuthDocRequest} providing options for the token request.
    * @returns A {@link ClientToken} object containing the URL and token needed to connect to the document.
    */
   public async getClientToken(
@@ -94,6 +95,7 @@ export class DocumentManager {
    * that one is created. If no docId is provided, a new document is created with a random ID.
    *
    * @param docId The ID of the document to get or create. If not provided, a new document with a random ID will be created.
+   * @param authDocRequest An optional {@link AuthDocRequest} providing options for the token request.
    * @returns A {@link ClientToken} object containing the URL and token needed to connect to the document.
    */
   public async getOrCreateDocAndToken(
@@ -141,6 +143,7 @@ export class DocumentManager {
  *
  * @param connectionString A connection string (starting with `ys://` or `yss://`) referring to a y-sweet server.
  * @param docId The ID of the document to get or create. If not provided, a new document with a random ID will be created.
+ * @param authDocRequest An optional {@link AuthDocRequest} providing options for the token request.
  * @returns A {@link ClientToken} object containing the URL and token needed to connect to the document.
  */
 export async function getOrCreateDocAndToken(
@@ -157,6 +160,7 @@ export async function getOrCreateDocAndToken(
  *
  * @param connectionString A connection string (starting with `ys://` or `yss://`) referring to a y-sweet server.
  * @param docId The ID of the document to get a token for.
+ * @param authDocRequest An optional {@link AuthDocRequest} providing options for the token request.
  * @returns A {@link ClientToken} object containing the URL and token needed to connect to the document.
  */
 export async function getClientToken(

--- a/js-pkg/sdk/src/types.ts
+++ b/js-pkg/sdk/src/types.ts
@@ -28,3 +28,19 @@ export type ClientToken = {
 }
 
 export type CheckStoreResult = { ok: true } | { ok: false; error: string }
+
+export type Authorization = 'full' | 'read-only'
+
+export type AuthDocRequest = {
+  /** The authorization level to use for the document. Defaults to 'full' (not currently enforced). */
+  authorization?: Authorization
+
+  /** A user ID to associate with the token. Not currently used. */
+  userId?: string
+
+  /** Metadata to associate with the user accessing the document. Not currently used. */
+  metadata?: Record<string, any>
+
+  /** The number of seconds the token should be valid for. */
+  validForSeconds?: number
+}

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -283,7 +283,7 @@ describe.each(CONFIGURATIONS)(
       test('Connecting with 0 validForSeconds should fail', async () => {
         const docResult = await DOCUMENT_MANANGER.createDoc()
         const conn = await DOCUMENT_MANANGER.getDocConnection(docResult, { validForSeconds: 0 })
-  
+
         try {
           await conn.getAsUpdate()
           throw new Error('Expected error')

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeAll, afterAll } from 'vitest'
-import { DocumentManager } from '@y-sweet/sdk'
+import { DocumentManager, YSweetError } from '@y-sweet/sdk'
 import {
   createYjsProvider as createYjsProvider_,
   YSweetProviderParams,
@@ -280,6 +280,44 @@ describe.each(CONFIGURATIONS)(
     })
 
     if (configuration.useAuth) {
+      test('Connecting with 0 validForSeconds should fail', async () => {
+        const docResult = await DOCUMENT_MANANGER.createDoc()
+        const conn = await DOCUMENT_MANANGER.getDocConnection(docResult, { validForSeconds: 0 })
+  
+        try {
+          await conn.getAsUpdate()
+          throw new Error('Expected error')
+        } catch (e) {
+          if (e instanceof YSweetError) {
+            expect(e.cause.code).toBe('InvalidAuthProvided')
+          } else {
+            throw e
+          }
+        }
+      })
+
+      test.only('Connecting with 5 validForSeconds should work briefly', async () => {
+        const docResult = await DOCUMENT_MANANGER.createDoc()
+        const conn = await DOCUMENT_MANANGER.getDocConnection(docResult, { validForSeconds: 5 })
+
+        const update = await conn.getAsUpdate()
+        expect(update).toBeDefined()
+
+        // wait 8 seconds
+        await new Promise((resolve) => setTimeout(resolve, 8_000))
+
+        try {
+          await conn.getAsUpdate()
+          throw new Error('Expected error')
+        } catch (e) {
+          if (e instanceof YSweetError) {
+            expect(e.cause.code).toBe('InvalidAuthProvided')
+          } else {
+            throw e
+          }
+        }
+      }, 10_000)
+
       test('Attempting to connect to a document without auth should fail', async () => {
         const docResult = await DOCUMENT_MANANGER.createDoc()
         const key = await DOCUMENT_MANANGER.getClientToken(docResult)

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -284,6 +284,9 @@ describe.each(CONFIGURATIONS)(
         const docResult = await DOCUMENT_MANANGER.createDoc()
         const conn = await DOCUMENT_MANANGER.getDocConnection(docResult, { validForSeconds: 0 })
 
+        // wait 1 second
+        await new Promise((resolve) => setTimeout(resolve, 1_000))
+
         try {
           await conn.getAsUpdate()
           throw new Error('Expected error')
@@ -296,7 +299,7 @@ describe.each(CONFIGURATIONS)(
         }
       })
 
-      test.only('Connecting with 5 validForSeconds should work briefly', async () => {
+      test('Connecting with 5 validForSeconds should work briefly', async () => {
         const docResult = await DOCUMENT_MANANGER.createDoc()
         const conn = await DOCUMENT_MANANGER.getDocConnection(docResult, { validForSeconds: 5 })
 


### PR DESCRIPTION
Adds `valid_for_seconds` to the auth body request. We weren't actually parsing the request body before, so we do that now.

Introduces a newtype to avoid mixing up the current time and expiration times.

Closes #309