### PR TITLE
[y sweet/client] support provider.on()

### DIFF
--- a/examples/nextjs/src/app/(demos)/slate/SlateEditor.tsx
+++ b/examples/nextjs/src/app/(demos)/slate/SlateEditor.tsx
@@ -18,8 +18,8 @@ export function SlateEditor() {
   }, [yDoc])
 
   useEffect(() => {
-    provider.observable.on('sync', setConnected)
-    return () => provider.observable.off('sync', setConnected)
+    provider.on('sync', setConnected)
+    return () => provider.off('sync', setConnected)
   }, [provider])
 
   if (!connected) return 'Loading...'

--- a/examples/nextjs/src/app/tldraw/useYjsStore.ts
+++ b/examples/nextjs/src/app/tldraw/useYjsStore.ts
@@ -232,18 +232,18 @@ export function useYjsStore() {
         return
       }
 
-      provider.observable.off('sync', handleSync)
+      provider.off('sync', handleSync)
 
       if (status === 'connected') {
         if (hasConnectedBefore) return
         hasConnectedBefore = true
-        provider.observable.on('sync', handleSync)
-        unsubs.push(() => provider.observable.off('sync', handleSync))
+        provider.on('sync', handleSync)
+        unsubs.push(() => provider.off('sync', handleSync))
       }
     }
 
-    provider.observable.on('status', handleStatusChange)
-    unsubs.push(() => provider.observable.off('status', handleStatusChange))
+    provider.on('status', handleStatusChange)
+    unsubs.push(() => provider.off('status', handleStatusChange))
 
     return () => {
       unsubs.forEach((fn) => fn())

--- a/tests/src/convert.test.ts
+++ b/tests/src/convert.test.ts
@@ -36,7 +36,7 @@ async function connectToDoc(server: Server, docId: string): Promise<Y.Doc> {
   })
 
   await new Promise<void>((resolve, reject) => {
-    provider.observable.on('synced', resolve)
+    provider.on('synced', resolve)
 
     setTimeout(() => {
       reject('Timed out waiting for sync')

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -127,8 +127,8 @@ describe.each(CONFIGURATIONS)(
       const provider = await createYjsProvider(doc, docResult.docId, getClientToken, {})
 
       await new Promise((resolve, reject) => {
-        provider.observable.on('synced', resolve)
-        provider.observable.on('syncing', reject)
+        provider.on('synced', resolve)
+        provider.on('syncing', reject)
       })
     })
 
@@ -227,7 +227,7 @@ describe.each(CONFIGURATIONS)(
 
       await new Promise<void>((resolve, reject) => {
         setTimeout(() => reject('Expected to disconnect.'), 1_000)
-        provider.observable.on('connection-close', () => {
+        provider.on('connection-close', () => {
           resolve()
         })
       })
@@ -240,7 +240,7 @@ describe.each(CONFIGURATIONS)(
       // Reconnect to the doc.
       provider.connect()
       await new Promise<void>((resolve, reject) => {
-        provider.observable.on('status', (event: { status: string }) => {
+        provider.on('status', (event: { status: string }) => {
           if (event.status === 'connected') {
             resolve()
           } else {

--- a/tests/src/util.ts
+++ b/tests/src/util.ts
@@ -2,8 +2,8 @@ import { YSweetProvider } from '@y-sweet/react'
 
 export async function waitForProviderSync(provider: YSweetProvider, timeoutMillis: number = 1_000) {
   return new Promise((resolve, reject) => {
-    provider.observable.on('synced', resolve)
-    provider.observable.on('syncing', reject)
+    provider.on('synced', resolve)
+    provider.on('syncing', reject)
 
     setTimeout(() => reject('Timed out waiting for provider to sync.'), timeoutMillis)
   })


### PR DESCRIPTION
When we [reworked the provider to support reconnections](https://github.com/jamsocket/y-sweet/pull/292), we lost the `on`/`off`/`once` methods from the `Observer` base class that used to exist on `YSweetProvider`. It turns out those methods are often used by third-party libraries. This PR adds support for those back in.