### PR TITLE
Fix docstring

### DIFF
--- a/python/src/y_sweet_sdk/update.py
+++ b/python/src/y_sweet_sdk/update.py
@@ -21,7 +21,7 @@ class UpdateContext:
     conn = dm.get_connection("my-doc")
 
     with conn.for_update() as doc:
-        my_map = doc.get("my-map", pycrdt.Map)
+        my_map = doc.get("my-map", type=pycrdt.Map)
         my_map['foo'] = 'bar'
     ```
     """


### PR DESCRIPTION
The pycrdt API requires this to be passed as a named parameter.

Eventually we should add python doctest infrastructure, but it's hard when it requires a y-sweet server to be running.