### PR TITLE
Turn off safe mode for next.js demos

### DIFF
--- a/examples/nextjs/next.config.js
+++ b/examples/nextjs/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  reactStrictMode: false,
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Next.js uses safe mode by default, so in development components are rendered multiple times. This leads to a bad experience for users who are poking around:

- The y-sweet debugger console log message is duplicated when running locally
<img width="1513" alt="image" src="https://github.com/user-attachments/assets/ec12e924-077c-4cae-910a-f2ddda9a6c9f">

- Two websocket connections are established, making it harder to debug.