### PR TITLE
Add ^19.0.0 to @y-sweet/react peer dependencies

### DIFF
--- a/js-pkg/react/package.json
+++ b/js-pkg/react/package.json
@@ -43,7 +43,7 @@
     "url": "https://github.com/drifting-in-space/y-sweet/issues"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "yjs": "^13.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes https://github.com/jamsocket/y-sweet/issues/323

Looks like as of the stable release of Next.js 15 on October 21st, [Next.js uses React 19 as a default](https://nextjs.org/blog/next-15#react-19) which means that installs with e.g. `create-next-app` will fail. This should fix the issue.