### PR TITLE
Add ^19.0.0-rc to @y-sweet/react peer dependencies

### DIFF
--- a/js-pkg/react/package.json
+++ b/js-pkg/react/package.json
@@ -43,8 +43,8 @@
     "url": "https://github.com/drifting-in-space/y-sweet/issues"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "yjs": "^13.0.0"
+    "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+    "yjs": "^13"
   },
   "dependencies": {
     "@y-sweet/client": "0.6.1",


### PR DESCRIPTION
Follow-up to https://github.com/jamsocket/y-sweet/pull/336 — `^19.0.0` actually doesn't match pre-releases, which is what Next.js is including (`react@19.0.0-rc-66855b96-20241106`). `^19.0.0-rc` matches all pre-releases, as confirmed by https://semver.npmjs.com.

Also, `^19` desugars to `^19.0.0` so I just removed the extraneous `.0.0`s.