### PR TITLE
create-y-sweet-app@1.0.1

### DIFF
--- a/js-pkg/create-y-sweet-app/package.json
+++ b/js-pkg/create-y-sweet-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-y-sweet-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "bin": {
     "create-y-sweet-app": "src/run.js"


### PR DESCRIPTION
Bumps `create-y-sweet-app` to 1.0.1 to match the npm version.