### PR TITLE
Allow foreign origins to auth with demo server

### DIFF
--- a/examples/nextjs/src/app/api/auth/route.ts
+++ b/examples/nextjs/src/app/api/auth/route.ts
@@ -2,10 +2,21 @@ import { CONNECTION_STRING } from '@/lib/config'
 import { getOrCreateDocAndToken } from '@y-sweet/sdk'
 import { NextResponse } from 'next/server'
 
+const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'POST',
+  'access-control-allow-headers': 'content-type',
+}
+
+export async function OPTIONS(request: Request) {
+  return new Response(null, { status: 204, headers: CORS_HEADERS })
+}
+
 export async function POST(request: Request) {
   // In a production app, you'd want to validate that the user is authenticated
   // and has access to the given doc.
+
   const { docId } = await request.json()
   const clientToken = await getOrCreateDocAndToken(CONNECTION_STRING, docId)
-  return NextResponse.json(clientToken)
+  return NextResponse.json(clientToken, { headers: CORS_HEADERS })
 }


### PR DESCRIPTION
This adds CORS headers to the example instance at [demos.y-sweet.dev](https://demos.y-sweet-dev). Right now I'm just allowlisting `demos.y-sweet.dev`, `blocknotejs.org` and `blocknote-main.vercel.app` (their playground website).

- Probably will get rid of `localhost` before merging; I need it to test the BlockNote docs locally but arguably we don't want to let people use this as a free local testing instance.
- Maybe will add Stackblitz? The BlockNote example has a link to open in Stackblitz which won't work unless we allowlist it, but we might not want to for the same reason as `localhost.