### PR TITLE
Implement events for sync status

### DIFF
--- a/crates/y-sweet-core/src/doc_connection.rs
+++ b/crates/y-sweet-core/src/doc_connection.rs
@@ -22,6 +22,8 @@ type Callback = Arc<dyn Fn(&[u8]) + 'static>;
 #[cfg(feature = "sync")]
 type Callback = Arc<dyn Fn(&[u8]) + 'static + Send + Sync>;
 
+const SYNC_STATUS_MESSAGE: u8 = 102;
+
 pub struct DocConnection {
     awareness: Arc<RwLock<Awareness>>,
     #[allow(unused)] // acts as RAII guard
@@ -183,6 +185,10 @@ impl DocConnection {
                 }
                 let mut awareness = a.write().unwrap();
                 protocol.handle_awareness_update(&mut awareness, update)
+            }
+            Message::Custom(SYNC_STATUS_MESSAGE, data) => {
+                // Respond to the client with the same payload it sent.
+                Ok(Some(Message::Custom(SYNC_STATUS_MESSAGE, data)))
             }
             Message::Custom(tag, data) => {
                 let mut awareness = a.write().unwrap();

--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -17,7 +17,6 @@ use futures::{SinkExt, StreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{
-    net::SocketAddr,
     sync::{Arc, RwLock},
     time::Duration,
 };

--- a/examples/nextjs/src/app/(demos)/color-grid/ColorGrid.tsx
+++ b/examples/nextjs/src/app/(demos)/color-grid/ColorGrid.tsx
@@ -14,7 +14,7 @@ export function ColorGrid() {
   const [color, setColor] = useState<string | null>(COLORS[0])
 
   return (
-    <div className="space-y-3 p-4 lg:p-8">
+    <div className="space-y-3">
       <Title>Color Grid</Title>
       <div className="space-x-2 flex flex-row">
         {COLORS.map((c) => (

--- a/examples/nextjs/src/app/(demos)/color-grid/page.tsx
+++ b/examples/nextjs/src/app/(demos)/color-grid/page.tsx
@@ -1,12 +1,16 @@
 import { YDocProvider } from '@y-sweet/react'
 import { randomId } from '@/lib/utils'
 import { ColorGrid } from './ColorGrid'
+import StateIndicator from '@/components/StateIndicator'
 
 export default function Home({ searchParams }: { searchParams: { doc: string } }) {
   const docId = searchParams.doc ?? randomId()
   return (
     <YDocProvider docId={docId} setQueryParam="doc" authEndpoint="/api/auth">
-      <ColorGrid />
+      <div className="p-4 lg:p-8">
+        <StateIndicator />
+        <ColorGrid />
+      </div>
     </YDocProvider>
   )
 }

--- a/examples/nextjs/src/components/StateIndicator.tsx
+++ b/examples/nextjs/src/components/StateIndicator.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { STATUS_CONNECTED } from '@y-sweet/client'
+import { useConnectionStatus, useHasLocalChanges } from '@y-sweet/react'
+
+export default function StateIndicator() {
+  let connectionStatus = useConnectionStatus()
+  let hasLocalChanges = useHasLocalChanges()
+
+  let statusColor = connectionStatus === STATUS_CONNECTED ? 'bg-green-500' : 'bg-red-500'
+  let syncedColor = hasLocalChanges ? 'bg-red-500' : 'bg-green-500'
+
+  return (
+    <div className="mb-4">
+      <div className="flex flex-row items-center text-xs space-x-1 w-fit bg-white rounded-md p-1 text-gray-500">
+        <div>CONNECTED:</div>
+        <div
+          className={`w-3 h-3 rounded-full transition-colors ${statusColor}`}
+          title={connectionStatus}
+        ></div>
+        <div>SYNCED:</div>
+        <div
+          className={`w-3 h-3 rounded-full transition-colors ${syncedColor}`}
+          title={hasLocalChanges ? 'Unsynced local changes.' : 'No unsynced local changes.'}
+        ></div>
+      </div>
+    </div>
+  )
+}

--- a/js-pkg/client/src/main.ts
+++ b/js-pkg/client/src/main.ts
@@ -1,7 +1,31 @@
-import { YSweetProvider, type YSweetProviderParams, type AuthEndpoint } from './provider'
-import * as Y from 'yjs'
 import { ClientToken, encodeClientToken } from '@y-sweet/sdk'
-export { YSweetProvider, YSweetProviderParams, AuthEndpoint }
+import * as Y from 'yjs'
+import {
+  type AuthEndpoint,
+  EVENT_CONNECTION_STATUS,
+  EVENT_LOCAL_CHANGES,
+  STATUS_CONNECTED,
+  STATUS_CONNECTING,
+  STATUS_ERROR,
+  STATUS_HANDSHAKING,
+  STATUS_OFFLINE,
+  YSweetProvider,
+  type YSweetProviderParams,
+  type YSweetStatus,
+} from './provider'
+export {
+  AuthEndpoint,
+  EVENT_CONNECTION_STATUS,
+  EVENT_LOCAL_CHANGES,
+  STATUS_CONNECTED,
+  STATUS_CONNECTING,
+  STATUS_ERROR,
+  STATUS_HANDSHAKING,
+  STATUS_OFFLINE,
+  YSweetProvider,
+  YSweetProviderParams,
+  YSweetStatus,
+}
 
 /**
  * Given a docId and {@link AuthEndpoint}, create a {@link YSweetProvider} for it.

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -385,7 +385,6 @@ export class YSweetProvider {
       this.connect()
     }
 
-    console.log('setStatus', status)
     if (this.status.status !== status.status) {
       this.status = status
       this.emit('status', status)

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -365,13 +365,12 @@ export class YSweetProvider {
   }
 
   protected emit(eventName: YSweetEvent, data: any = null): void {
-    const listeners = this.listeners.get(eventName) || new Set()
-
-    for (const listener of listeners) {
-      listener(data)
+    const listeners = this.listeners.get(eventName)
+    if (listeners) {
+      for (const listener of listeners) {
+        listener(data)
+      }
     }
-    this.setSynced(false)
-    this.setStatus({ status: STATUS_DISCONNECTED })
   }
 
   private setSynced(state: boolean) {

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -425,10 +425,6 @@ export class YSweetProvider {
   }
 
   private setStatus(status: YSweetStatus) {
-    if (status.status === STATUS_DISCONNECTED && this.shouldConnect) {
-      this.connect()
-    }
-
     if (this.status.status !== status.status) {
       this.status = status
       this.emit('status', status)

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -338,7 +338,7 @@ export class YSweetProvider {
   }
 
   private websocketClose(event: CloseEvent) {
-    this.emit('connection-close', event)
+    this.emit(EVENT_CONNECTION_CLOSE, event)
     this.setSynced(false)
     this.setStatus({ status: STATUS_DISCONNECTED })
 
@@ -370,12 +370,14 @@ export class YSweetProvider {
     for (const listener of listeners) {
       listener(data)
     }
+    this.setSynced(false)
+    this.setStatus({ status: STATUS_DISCONNECTED })
   }
 
   private setSynced(state: boolean) {
     if (this.synced !== state) {
       this.synced = state
-      this.emit('sync', state)
+      this.emit(EVENT_SYNC, state)
     }
   }
 

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -47,7 +47,7 @@ type YSweetStatus = {
 }
 
 type WebSocketPolyfillType = {
-  new(url: string | URL): WebSocket
+  new (url: string | URL): WebSocket
   prototype: WebSocket
   readonly CLOSED: number
   readonly CLOSING: number

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -409,7 +409,6 @@ export class YSweetProvider {
   }
 
   protected emit(eventName: YSweetEvent, data: any = null): void {
-    console.log('Emitting event', eventName, data)
     const listeners = this.listeners.get(eventName)
     if (listeners) {
       for (const listener of listeners) {

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -107,8 +107,7 @@ async function getClientToken(authEndpoint: AuthEndpoint, roomname: string): Pro
 export class YSweetProvider {
   private websocket: WebSocket | null = null
   public clientToken: ClientToken | null = null
-  private initialSync: boolean = false
-  private synced: boolean = false
+  public synced: boolean = false
   private status: YSweetStatus = { status: STATUS_DISCONNECTED }
   public awareness: awarenessProtocol.Awareness
   private WebSocketPolyfill: WebSocketPolyfillType

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -381,6 +381,11 @@ export class YSweetProvider {
   }
 
   private setStatus(status: YSweetStatus) {
+    if (status.status === STATUS_DISCONNECTED && this.shouldConnect) {
+      this.connect()
+    }
+
+    console.log('setStatus', status)
     if (this.status.status !== status.status) {
       this.status = status
       this.emit('status', status)

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -232,7 +232,10 @@ export class YSweetProvider {
       this.on(EVENT_CONNECTION_STATUS, statusListener)
     })
 
-    this.setupWs(clientToken)
+    let url = this.generateUrl(clientToken)
+    this.setStatus(STATUS_CONNECTING)
+    const websocket = new (this.WebSocketPolyfill || WebSocket)(url)
+    this.bindWebsocket(websocket)
 
     return promise
   }
@@ -298,15 +301,12 @@ export class YSweetProvider {
     this.websocket.onerror = this.websocketError.bind(this)
   }
 
-  private setupWs(clientToken: ClientToken) {
-    let url = clientToken.url + `/${clientToken.docId}`
+  generateUrl(clientToken: ClientToken) {
+    const url = clientToken.url + `/${clientToken.docId}`
     if (clientToken.token) {
-      url = url + `?token=${clientToken.token}`
+      return `${url}?token=${clientToken.token}`
     }
-
-    this.setStatus(STATUS_CONNECTING)
-    const websocket = new (this.WebSocketPolyfill || WebSocket)(url)
-    this.bindWebsocket(websocket)
+    return url
   }
 
   private syncStep1() {

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -4,7 +4,12 @@ import * as encoding from 'lib0/encoding'
 import * as awarenessProtocol from 'y-protocols/awareness'
 import * as syncProtocol from 'y-protocols/sync'
 import * as Y from 'yjs'
-import { EVENT_CONNECTION_ERROR, WebSocketCompatLayer, YWebsocketEvent } from './ws-status'
+import {
+  EVENT_CONNECTION_CLOSE,
+  EVENT_CONNECTION_ERROR,
+  WebSocketCompatLayer,
+  YWebsocketEvent,
+} from './ws-status'
 
 const MESSAGE_SYNC = 0
 const MESSAGE_QUERY_AWARENESS = 3
@@ -391,6 +396,7 @@ export class YSweetProvider {
   }
 
   private websocketClose(event: CloseEvent) {
+    this.emit(EVENT_CONNECTION_CLOSE, event)
     this.setStatus(STATUS_ERROR)
     this.connect()
 
@@ -475,16 +481,38 @@ export class YSweetProvider {
     }
   }
 
-  /* =============== y-websocket compatibility ================= */
+  /**
+   * Whether the provider should attempt to connect.
+   *
+   * @deprecated use provider.status !== 'offline' instead, or call `provider.connect()` / `provider.disconnect()` to set.
+   */
+  get shouldConnect(): boolean {
+    return this.status !== STATUS_OFFLINE
+  }
 
+  /**
+   * Whether the underlying websocket is connected.
+   *
+   * @deprecated use provider.status === 'connected' || provider.status === 'handshaking' instead.
+   */
   get wsconnected() {
     return this.status === STATUS_CONNECTED || this.status === STATUS_HANDSHAKING
   }
 
+  /**
+   * Whether the underlying websocket is connecting.
+   *
+   * @deprecated use provider.status === 'connecting' instead.
+   */
   get wsconnecting() {
     return this.status === STATUS_CONNECTING
   }
 
+  /**
+   * Whether the document is synced. (For compatibility with y-websocket.)
+   *
+   * @deprecated use provider.status === 'connected' instead.
+   * */
   get synced() {
     return this.status === STATUS_CONNECTED
   }

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -47,7 +47,7 @@ type YSweetStatus = {
 }
 
 type WebSocketPolyfillType = {
-  new (url: string | URL): WebSocket
+  new(url: string | URL): WebSocket
   prototype: WebSocket
   readonly CLOSED: number
   readonly CLOSING: number
@@ -409,11 +409,9 @@ export class YSweetProvider {
   }
 
   protected emit(eventName: YSweetEvent, data: any = null): void {
-    const listeners = this.listeners.get(eventName)
-    if (listeners) {
-      for (const listener of listeners) {
-        listener(data)
-      }
+    const listeners = this.listeners.get(eventName) || new Set()
+    for (const listener of listeners) {
+      listener(data)
     }
   }
 

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -363,7 +363,7 @@ export class YSweetProvider {
   }
 
   private websocketOpen() {
-    this.setStatus(STATUS_CONNECTED)
+    this.setStatus(STATUS_HANDSHAKING)
     this.syncStep1()
     this.checkSync()
     this.broadcastAwareness()

--- a/js-pkg/client/src/ws-status.ts
+++ b/js-pkg/client/src/ws-status.ts
@@ -1,0 +1,81 @@
+/** Status API compatibility with y-websocket */
+
+import {
+  EVENT_CONNECTION_STATUS,
+  EVENT_LOCAL_CHANGES,
+  STATUS_CONNECTED,
+  STATUS_CONNECTING,
+  STATUS_HANDSHAKING,
+  STATUS_OFFLINE,
+  YSweetProvider,
+  YSweetStatus,
+} from './provider'
+
+export const EVENT_STATUS = 'status'
+/** Fired when the _initial_ sync is complete. Only refired after that if there is a reconnection. */
+export const EVENT_SYNC = 'sync'
+export const EVENT_CONNECTION_CLOSE = 'connection-close'
+export const EVENT_CONNECTION_ERROR = 'connection-error'
+
+/** Alias of EVENT_SYNC for compatibility with y-websocket.
+ * Ref: https://github.com/yjs/y-websocket/blob/aa4220407bda51ab6282d1291de6493c136c2089/src/y-websocket.js#L404
+ */
+export const EVENT_SYNCED = 'synced'
+
+/**
+ * Ref: https://github.com/yjs/y-websocket/blob/aa4220407bda51ab6282d1291de6493c136c2089/README.md?plain=1#L119-L125
+ */
+export type YWebsocketEvent =
+  | typeof EVENT_STATUS
+  | typeof EVENT_SYNC
+  | typeof EVENT_CONNECTION_CLOSE
+  | typeof EVENT_CONNECTION_ERROR
+  | typeof EVENT_SYNCED
+
+const WEBSOCKET_STATUS_CONNECTED = 'connected'
+const WEBSOCKET_STATUS_DISCONNECTED = 'disconnected'
+const WEBSOCKET_STATUS_CONNECTING = 'connecting'
+
+export type YWebSocketStatus =
+  | typeof WEBSOCKET_STATUS_CONNECTED
+  | typeof WEBSOCKET_STATUS_DISCONNECTED
+  | typeof WEBSOCKET_STATUS_CONNECTING
+
+function translateStatus(status: YSweetStatus): YWebSocketStatus {
+  if (status === STATUS_CONNECTED) {
+    return WEBSOCKET_STATUS_CONNECTED
+  } else if ([STATUS_CONNECTING, STATUS_HANDSHAKING].includes(status)) {
+    return WEBSOCKET_STATUS_CONNECTING
+  } else {
+    return WEBSOCKET_STATUS_DISCONNECTED
+  }
+}
+
+export class WebSocketCompatLayer {
+  lastStatus: YWebSocketStatus = WEBSOCKET_STATUS_DISCONNECTED
+  lastSyncStatus = false
+
+  constructor(private provider: YSweetProvider) {
+    this.provider.on(EVENT_CONNECTION_STATUS, this.updateStatus.bind(this))
+  }
+
+  updateStatus(status: YSweetStatus) {
+    const newStatus = translateStatus(status)
+
+    const syncStatus = status === STATUS_CONNECTED
+
+    if (this.lastSyncStatus !== syncStatus) {
+      this.lastSyncStatus = syncStatus
+
+      // Yjs emits both `synced` and `sync` events for legacy reasons.
+      // Ref: https://github.com/yjs/y-websocket/blob/aa4220407bda51ab6282d1291de6493c136c2089/src/y-websocket.js#L404
+      this.provider.emit(EVENT_SYNC, syncStatus)
+      this.provider.emit(EVENT_SYNCED, syncStatus)
+    }
+
+    if (this.lastStatus !== newStatus) {
+      this.lastStatus = newStatus
+      this.provider.emit(EVENT_CONNECTION_STATUS, newStatus)
+    }
+  }
+}

--- a/js-pkg/client/src/ws-status.ts
+++ b/js-pkg/client/src/ws-status.ts
@@ -75,7 +75,7 @@ export class WebSocketCompatLayer {
 
     if (this.lastStatus !== newStatus) {
       this.lastStatus = newStatus
-      this.provider.emit(EVENT_CONNECTION_STATUS, newStatus)
+      this.provider.emit(EVENT_STATUS, { status: newStatus })
     }
   }
 }

--- a/js-pkg/client/src/ws-status.ts
+++ b/js-pkg/client/src/ws-status.ts
@@ -2,11 +2,9 @@
 
 import {
   EVENT_CONNECTION_STATUS,
-  EVENT_LOCAL_CHANGES,
   STATUS_CONNECTED,
   STATUS_CONNECTING,
   STATUS_HANDSHAKING,
-  STATUS_OFFLINE,
   YSweetProvider,
   YSweetStatus,
 } from './provider'

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -8,7 +8,7 @@ import {
 import { WebSocket } from 'ws'
 import * as Y from 'yjs'
 import { Server, ServerConfiguration } from './server'
-import { waitForProviderSync } from './util'
+import { waitForLocalChangesSync, waitForProviderSync } from './util'
 
 /**
  * Wraps `createYjsProvider` with a polyfill for `WebSocket` and
@@ -134,7 +134,7 @@ describe.each(CONFIGURATIONS)(
       const getClientToken = async () => await DOCUMENT_MANANGER.getClientToken(docResult)
 
       const doc = new Y.Doc()
-      const provider = await createYjsProvider(doc, docResult.docId, getClientToken, {})
+      const provider = createYjsProvider(doc, docResult.docId, getClientToken, {})
 
       await waitForProviderSync(provider)
     })
@@ -166,7 +166,7 @@ describe.each(CONFIGURATIONS)(
       const getClientToken = async () => await DOCUMENT_MANANGER.getClientToken(docResult)
 
       const doc = new Y.Doc()
-      const provider = await createYjsProvider(doc, docResult.docId, getClientToken, {})
+      const provider = createYjsProvider(doc, docResult.docId, getClientToken, {})
 
       let map = doc.getMap('test')
       map.set('foo', 'bar')
@@ -200,7 +200,7 @@ describe.each(CONFIGURATIONS)(
 
       const getClientToken = async () => await DOCUMENT_MANANGER.getClientToken(docResult)
 
-      const provider = await createYjsProvider(doc, docResult.docId, getClientToken, {})
+      const provider = createYjsProvider(doc, docResult.docId, getClientToken, {})
       await waitForProviderSync(provider)
 
       let newMap = doc.getMap('abc123')
@@ -224,29 +224,10 @@ describe.each(CONFIGURATIONS)(
       const doc = new Y.Doc()
 
       // Connect to the doc.
-      let provider = await createYjsProvider(doc, docResult.docId, getClientToken, {})
-
-      await waitForProviderSync(provider)
-
-      // Disconnect.
-      provider.destroy()
+      const provider = createYjsProvider(doc, docResult.docId, getClientToken, {})
 
       // Modify the doc while offline.
       doc.getMap('test').set('foo', 'bar')
-
-      // Reconnect to the doc.
-      provider = createYjsProvider(doc, docResult.docId, getClientToken, {})
-      await new Promise<void>((resolve, reject) => {
-        provider.on('status', (event: { status: string }) => {
-          if (event.status === 'connected') {
-            resolve()
-          }
-        })
-
-        setTimeout(() => {
-          reject('Timed out waiting for provider to reconnect.')
-        }, 5_000)
-      })
 
       await waitForProviderSync(provider)
       expect(provider.synced).toBe(true)
@@ -255,7 +236,7 @@ describe.each(CONFIGURATIONS)(
       const doc2 = new Y.Doc()
 
       // Connect to the doc.
-      const provider2 = await createYjsProvider(doc2, docResult.docId, getClientToken, {})
+      const provider2 = createYjsProvider(doc2, docResult.docId, getClientToken, {})
 
       expect(doc2.getMap('test').get('foo')).toBeUndefined()
 
@@ -343,7 +324,7 @@ describe.each(CONFIGURATIONS)(
       // Connect to the doc and verify the content
       const getClientToken = async () => await DOCUMENT_MANANGER.getClientToken(docResult)
       const newDoc = new Y.Doc()
-      const provider = await createYjsProvider(newDoc, docResult.docId, getClientToken, {})
+      const provider = createYjsProvider(newDoc, docResult.docId, getClientToken, {})
 
       await waitForProviderSync(provider)
 

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -8,7 +8,7 @@ import {
 import { WebSocket } from 'ws'
 import * as Y from 'yjs'
 import { Server, ServerConfiguration } from './server'
-import { waitForLocalChangesSync, waitForProviderSync } from './util'
+import { waitForProviderSync } from './util'
 
 /**
  * Wraps `createYjsProvider` with a polyfill for `WebSocket` and

--- a/tests/src/util.ts
+++ b/tests/src/util.ts
@@ -1,9 +1,33 @@
+import { EVENT_LOCAL_CHANGES } from '@y-sweet/client'
 import { YSweetProvider } from '@y-sweet/react'
 
 export async function waitForProviderSync(provider: YSweetProvider, timeoutMillis: number = 1_000) {
-  return new Promise((resolve, reject) => {
-    provider.on('sync', resolve)
+  return new Promise<void>((resolve, reject) => {
+    provider.on('sync', (synced) => {
+      if (synced) {
+        resolve()
+      }
+    })
 
     setTimeout(() => reject('Timed out waiting for provider to sync.'), timeoutMillis)
+  })
+}
+
+export async function waitForLocalChangesSync(
+  provider: YSweetProvider,
+  timeoutMillis: number = 1_000,
+) {
+  if (!provider.hasLocalChanges) {
+    return
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    provider.on(EVENT_LOCAL_CHANGES, (hasLocalChanges) => {
+      if (!hasLocalChanges) {
+        resolve()
+      }
+    })
+
+    setTimeout(() => reject('Timed out waiting for local changes to sync up.'), timeoutMillis)
   })
 }

--- a/tests/src/util.ts
+++ b/tests/src/util.ts
@@ -12,22 +12,3 @@ export async function waitForProviderSync(provider: YSweetProvider, timeoutMilli
     setTimeout(() => reject('Timed out waiting for provider to sync.'), timeoutMillis)
   })
 }
-
-export async function waitForLocalChangesSync(
-  provider: YSweetProvider,
-  timeoutMillis: number = 1_000,
-) {
-  if (!provider.hasLocalChanges) {
-    return
-  }
-
-  return new Promise<void>((resolve, reject) => {
-    provider.on(EVENT_LOCAL_CHANGES, (hasLocalChanges) => {
-      if (!hasLocalChanges) {
-        resolve()
-      }
-    })
-
-    setTimeout(() => reject('Timed out waiting for local changes to sync up.'), timeoutMillis)
-  })
-}


### PR DESCRIPTION
`y-websocket` has a `synced` flag, but it is a bit misleading because it only tells whether the initial handshake was completed. Knowing whether a document was synced _in general_ for `y-protocols` is a bit tricky, because we would need to compare the state vector and delete set.

When using WebSockets, we can take advantage of the ordering guarantee and synchronous message processing in Y-Sweet to implement a very simple check of sync.

The client stores two numbers, `lastSyncSent` and `lastSyncAcked`. When it sends an update to the server, it also increments `lastSyncSent` and then sends a separate `messageSyncStatus` message containing that number as the payload.

When the server receives a `messageSyncStatus`, it simply echoes it verbatim. When the client receives the `messageSyncStatus` in return, it updates `lastSyncAcked` to the payload of the message.

If `lastSyncAcked` = `lastSyncSent`, we know that all messages since the last update have been processed. Otherwise, there are outstanding changes.

This builds on #352 and will enable #306.

Demo:

https://github.com/user-attachments/assets/60d4aec2-f025-4e84-a594-28fbc84c67cb

