### PR TITLE
Add echo endpoint to server for sync check

### DIFF
--- a/crates/y-sweet-core/src/doc_connection.rs
+++ b/crates/y-sweet-core/src/doc_connection.rs
@@ -22,6 +22,8 @@ type Callback = Arc<dyn Fn(&[u8]) + 'static>;
 #[cfg(feature = "sync")]
 type Callback = Arc<dyn Fn(&[u8]) + 'static + Send + Sync>;
 
+const SYNC_STATUS_MESSAGE: u8 = 102;
+
 pub struct DocConnection {
     awareness: Arc<RwLock<Awareness>>,
     #[allow(unused)] // acts as RAII guard
@@ -183,6 +185,10 @@ impl DocConnection {
                 }
                 let mut awareness = a.write().unwrap();
                 protocol.handle_awareness_update(&mut awareness, update)
+            }
+            Message::Custom(SYNC_STATUS_MESSAGE, data) => {
+                // Respond to the client with the same payload it sent.
+                Ok(Some(Message::Custom(SYNC_STATUS_MESSAGE, data)))
             }
             Message::Custom(tag, data) => {
                 let mut awareness = a.write().unwrap();


### PR DESCRIPTION
This is extracted from #353 and includes only the server-side change.

It adds a custom message type that simply echoes back the content it received. Since the server processes messages sequentially, this is a way for a client to confirm that a message has been processed:

- send some message
- send a sync status message with a nonce
- when you have received a message with the same nonce back, you can assume the message has been processed