### PR TITLE
Normalize package.json

### DIFF
--- a/js-pkg/client/package.json
+++ b/js-pkg/client/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/drifting-in-space/y-sweet",
   "repository": {
     "type": "git",
-    "url": "https://github.com/drifting-in-space/y-sweet.git"
+    "url": "git+https://github.com/drifting-in-space/y-sweet.git"
   },
   "license": "MIT",
   "devDependencies": {

--- a/js-pkg/react/package.json
+++ b/js-pkg/react/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/drifting-in-space/y-sweet",
   "repository": {
     "type": "git",
-    "url": "https://github.com/drifting-in-space/y-sweet.git"
+    "url": "git+https://github.com/drifting-in-space/y-sweet.git"
   },
   "license": "MIT",
   "devDependencies": {

--- a/js-pkg/sdk/package.json
+++ b/js-pkg/sdk/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/drifting-in-space/y-sweet",
   "repository": {
     "type": "git",
-    "url": "https://github.com/drifting-in-space/y-sweet.git"
+    "url": "git+https://github.com/drifting-in-space/y-sweet.git"
   },
   "license": "MIT",
   "devDependencies": {

--- a/js-pkg/server/package.json
+++ b/js-pkg/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "y-sweet",
   "bin": {
-    "y-sweet": "./src/run.js"
+    "y-sweet": "src/run.js"
   },
   "scripts": {
     "postinstall": "node src/install.js",
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/drifting-in-space/y-sweet",
   "repository": {
     "type": "git",
-    "url": "https://github.com/drifting-in-space/y-sweet.git"
+    "url": "git+https://github.com/drifting-in-space/y-sweet.git"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
When attempting to push to npm, I get this:

```
Caused by:
    Failed to publish package: npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
    npm WARN publish errors corrected:
    npm WARN publish "bin[y-sweet]" script name was cleaned
    npm WARN publish "repository.url" was normalized to "git+https://github.com/drifting-in-space/y-sweet.git"
    npm notice 
    npm notice 📦  y-sweet@0.6.4
    npm notice === Tarball Contents === 
    npm notice 98B   .prettierrc      
    npm notice 791B  README.md        
    npm notice 584B  package.json     
    npm notice 1.7kB src/get-binary.js
    npm notice 59B   src/install.js   
    npm notice 284B  src/run.js       
    npm notice === Tarball Details === 
    npm notice name:          y-sweet                                 
    npm notice version:       0.6.4                                   
    npm notice filename:      y-sweet-0.6.4.tgz                       
    npm notice package size:  1.7 kB                                  
    npm notice unpacked size: 3.5 kB                                  
    npm notice shasum:        ce480c81d995a7706689bde2a4dc117625488e53
    npm notice integrity:     sha512-9tggH5+jvgpBh[...]WbbhWDbRFjhRg==
    npm notice total files:   6                                       
    npm notice 
    npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access
    npm ERR! code EOTP
    npm ERR! This operation requires a one-time password from your authenticator.
    npm ERR! You can provide a one-time password by passing --otp=<code> to the command you ran.
    npm ERR! If you already provided a one-time password then it is likely that you either typoed
    npm ERR! it, or it timed out. Please try again.
    
    npm ERR! A complete log of this run can be found in: /Users/paul/.npm/_logs/2024-12-12T23_05_10_818Z-debug-0.log
```