### PR TITLE
Prepare client package for jsr.io

### DIFF
--- a/js-pkg/client/jsr.json
+++ b/js-pkg/client/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@y-sweet/client",
+  "version": "0.6.4",
+  "license": "MIT",
+  "exports": "./src/main.ts"
+}

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -301,7 +301,7 @@ export class YSweetProvider {
     this.websocket.onerror = this.websocketError.bind(this)
   }
 
-  generateUrl(clientToken: ClientToken) {
+  generateUrl(clientToken: ClientToken): string {
     const url = clientToken.url + `/${clientToken.docId}`
     if (clientToken.token) {
       return `${url}?token=${clientToken.token}`
@@ -495,7 +495,7 @@ export class YSweetProvider {
    *
    * @deprecated use provider.status === 'connected' || provider.status === 'handshaking' instead.
    */
-  get wsconnected() {
+  get wsconnected(): boolean {
     return this.status === STATUS_CONNECTED || this.status === STATUS_HANDSHAKING
   }
 
@@ -504,7 +504,7 @@ export class YSweetProvider {
    *
    * @deprecated use provider.status === 'connecting' instead.
    */
-  get wsconnecting() {
+  get wsconnecting(): boolean {
     return this.status === STATUS_CONNECTING
   }
 
@@ -513,7 +513,7 @@ export class YSweetProvider {
    *
    * @deprecated use provider.status === 'connected' instead.
    * */
-  get synced() {
+  get synced(): boolean {
     return this.status === STATUS_CONNECTED
   }
 }


### PR DESCRIPTION
Seems worth trying out, in part for its built-in documentation viewer. If it works well, I'm tempted to remove docs.y-sweet.dev in favor of linking to jsr.io docs.