### PR TITLE
small refactor to clarify logic

### DIFF
--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -309,16 +309,10 @@ export class YSweetProvider {
   }
 
   private async ensureClientToken(): Promise<ClientToken> {
-    if (this.clientToken) {
-      return this.clientToken
-    }
-    if (typeof this.authEndpoint === 'string') {
+    if (this.clientToken === null) {
       this.clientToken = await getClientToken(this.authEndpoint, this.docId)
-      return this.clientToken
-    } else {
-      this.clientToken = await this.authEndpoint()
-      return this.clientToken
     }
+    return this.clientToken
   }
 
   /**


### PR DESCRIPTION
Small logic clarification I came across as I was catching up on the new provider. `getClientToken` already handles the `AuthEndpoint` type for both cases: when it's a `function` and when it's a `string`.