### PR TITLE
Fix debugger console logging in React hook

### DIFF
--- a/examples/nextjs/src/app/(demos)/color-grid/page.tsx
+++ b/examples/nextjs/src/app/(demos)/color-grid/page.tsx
@@ -6,7 +6,7 @@ import StateIndicator from '@/components/StateIndicator'
 export default function Home({ searchParams }: { searchParams: { doc: string } }) {
   const docId = searchParams.doc ?? randomId()
   return (
-    <YDocProvider docId={docId} setQueryParam="doc" authEndpoint="/api/auth" offlineSupport={true} showDebuggerLink={true}>
+    <YDocProvider docId={docId} setQueryParam="doc" authEndpoint="/api/auth" offlineSupport={true}>
       <div className="p-4 lg:p-8">
         <StateIndicator />
         <ColorGrid />

--- a/examples/nextjs/src/app/(demos)/color-grid/page.tsx
+++ b/examples/nextjs/src/app/(demos)/color-grid/page.tsx
@@ -6,7 +6,7 @@ import StateIndicator from '@/components/StateIndicator'
 export default function Home({ searchParams }: { searchParams: { doc: string } }) {
   const docId = searchParams.doc ?? randomId()
   return (
-    <YDocProvider docId={docId} setQueryParam="doc" authEndpoint="/api/auth" offlineSupport={true}>
+    <YDocProvider docId={docId} setQueryParam="doc" authEndpoint="/api/auth" offlineSupport={true} showDebuggerLink={true}>
       <div className="p-4 lg:p-8">
         <StateIndicator />
         <ColorGrid />

--- a/js-pkg/client/src/main.ts
+++ b/js-pkg/client/src/main.ts
@@ -1,4 +1,3 @@
-import { ClientToken, encodeClientToken } from '@y-sweet/sdk'
 import * as Y from 'yjs'
 import {
   type AuthEndpoint,
@@ -43,15 +42,4 @@ export function createYjsProvider(
   extraOptions: Partial<YSweetProviderParams> = {},
 ): YSweetProvider {
   return new YSweetProvider(authEndpoint, docId, doc, extraOptions)
-}
-
-/**
- * Get a URL to open the Y-Sweet Debugger for the given client token.
- *
- * @param clientToken The client token to open the debugger for.
- * @returns A debugger URL as a string.
- */
-export function debuggerUrl(clientToken: ClientToken): string {
-  const payload = encodeClientToken(clientToken)
-  return `https://debugger.y-sweet.dev/?payload=${payload}`
 }

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -1,4 +1,4 @@
-import { ClientToken } from '@y-sweet/sdk'
+import { encodeClientToken, type ClientToken } from '@y-sweet/sdk'
 import * as decoding from 'lib0/decoding'
 import * as encoding from 'lib0/encoding'
 import * as awarenessProtocol from 'y-protocols/awareness'
@@ -91,6 +91,9 @@ export type YSweetProviderParams = {
    * Defaults to `false`; set to `true` to enable.
    */
   offlineSupport?: boolean
+
+  /** Whether to show the debugger link. Defaults to true. */
+  showDebuggerLink?: boolean
 }
 
 async function getClientToken(authEndpoint: AuthEndpoint, roomname: string): Promise<ClientToken> {
@@ -143,6 +146,7 @@ export class YSweetProvider {
   private connectionTimeoutHandle: ReturnType<typeof setTimeout> | null = null
 
   private reconnectSleeper: Sleeper | null = null
+  private showDebuggerLink = true
 
   private indexedDBProvider: IndexedDBProvider | null = null
 
@@ -159,6 +163,13 @@ export class YSweetProvider {
    */
   private receivedAtLeastOneSyncResponse: boolean = false
 
+  private get debugUrl() {
+    if (!this.clientToken) return null
+
+    const payload = encodeClientToken(this.clientToken)
+    return `https://debugger.y-sweet.dev/?payload=${payload}`
+  }
+
   constructor(
     private authEndpoint: AuthEndpoint,
     private docId: string,
@@ -168,6 +179,8 @@ export class YSweetProvider {
     if (extraOptions.initialClientToken) {
       this.clientToken = extraOptions.initialClientToken
     }
+
+    this.showDebuggerLink = extraOptions.showDebuggerLink !== false
 
     // Sets up some event handlers for y-websocket compatibility.
     new WebSocketCompatLayer(this)
@@ -371,7 +384,9 @@ export class YSweetProvider {
     this.isConnecting = true
     this.setStatus(STATUS_CONNECTING)
 
-    while (![STATUS_OFFLINE, STATUS_CONNECTED].includes(this.status)) {
+    const lastDebugUrl = this.debugUrl
+
+    connecting: while (![STATUS_OFFLINE, STATUS_CONNECTED].includes(this.status)) {
       this.setStatus(STATUS_CONNECTING)
       let clientToken
       try {
@@ -391,7 +406,7 @@ export class YSweetProvider {
       for (let i = 0; i < RETRIES_BEFORE_TOKEN_REFRESH; i++) {
         if (await this.attemptToConnect(clientToken)) {
           this.retries = 0
-          break
+          break connecting
         }
 
         let timeout =
@@ -407,6 +422,17 @@ export class YSweetProvider {
     }
 
     this.isConnecting = false
+
+    if (this.showDebuggerLink && lastDebugUrl !== this.debugUrl) {
+      console.log(
+        `%cOpen this in Y-Sweet Debugger ⮕ ${this.debugUrl}`,
+        'font-size: 1.5em; display: block; padding: 10px;',
+      )
+      console.log(
+        '%cTo hide the debugger link, pass showDebuggerLink={false} to YDocProvider',
+        'font-style: italic;',
+      )
+    }
   }
 
   public disconnect() {

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -163,7 +163,8 @@ export class YSweetProvider {
    */
   private receivedAtLeastOneSyncResponse: boolean = false
 
-  private get debugUrl() {
+  /** @deprecated */
+  get debugUrl() {
     if (!this.clientToken) return null
 
     const payload = encodeClientToken(this.clientToken)
@@ -429,7 +430,7 @@ export class YSweetProvider {
         'font-size: 1.5em; display: block; padding: 10px;',
       )
       console.log(
-        '%cTo hide the debugger link, pass showDebuggerLink={false} to YDocProvider',
+        '%cTo hide the debugger link, set the showDebuggerLink option to false when creating the provider',
         'font-style: italic;',
       )
     }

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -60,7 +60,7 @@ export function useYSweetDebugUrl(): string {
     throw new Error('Yjs hooks must be used within a YDocProvider')
   }
 
-  return (yjsCtx.provider as any).debugUrl || ''
+  return yjsCtx.provider.debugUrl || ''
 }
 
 /**

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -245,12 +245,13 @@ export function YDocProvider(props: YDocProviderProps) {
     const provider = createYjsProvider(doc, docId, authEndpoint, {
       initialClientToken,
       offlineSupport: props.offlineSupport,
+      showDebuggerLink: props.showDebuggerLink,
     })
 
     setCtx({ doc, provider })
 
     return () => {
-      provider?.destroy()
+      provider.destroy()
       doc.destroy()
     }
   }, [docId])


### PR DESCRIPTION
The new Y-Sweet provider broke the code that printed the Y-Sweet debugger to the console, because the code that reads the active client token runs before the client token is fetched (since fetching now happens asynchronously). This fixes the debugger by installing an event listener on the provider, which is triggered when the client token becomes available.

Reported by Sorin [on discord](https://discord.com/channels/939641163265232947/1202346195142312019/1325396209770303489).