### PR TITLE
Support warning of unsaved changes

### DIFF
--- a/examples/nextjs/src/app/(demos)/color-grid/page.tsx
+++ b/examples/nextjs/src/app/(demos)/color-grid/page.tsx
@@ -4,7 +4,13 @@ import { ColorGrid } from './ColorGrid'
 export default function Home({ searchParams }: { searchParams: { doc: string } }) {
   const docId = searchParams.doc ?? randomId()
   return (
-    <YDocProvider docId={docId} setQueryParam="doc" authEndpoint="/api/auth" offlineSupport={true} warnOnClose={true}>
+    <YDocProvider
+      docId={docId}
+      setQueryParam="doc"
+      authEndpoint="/api/auth"
+      offlineSupport={true}
+      warnOnClose={true}
+    >
       <div className="p-4 lg:p-8">
         <ColorGrid />
       </div>

--- a/examples/nextjs/src/app/(demos)/color-grid/page.tsx
+++ b/examples/nextjs/src/app/(demos)/color-grid/page.tsx
@@ -4,7 +4,7 @@ import { ColorGrid } from './ColorGrid'
 export default function Home({ searchParams }: { searchParams: { doc: string } }) {
   const docId = searchParams.doc ?? randomId()
   return (
-    <YDocProvider docId={docId} setQueryParam="doc" authEndpoint="/api/auth" offlineSupport={true}>
+    <YDocProvider docId={docId} setQueryParam="doc" authEndpoint="/api/auth" offlineSupport={true} warnOnClose={true}>
       <div className="p-4 lg:p-8">
         <ColorGrid />
       </div>

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -186,7 +186,6 @@ export class YSweetProvider {
     private doc: Y.Doc,
     extraOptions: Partial<YSweetProviderParams> = {},
   ) {
-    this.handleBeforeUnload = this.handleBeforeUnload.bind(this)
     if (extraOptions.initialClientToken) {
       this.clientToken = extraOptions.initialClientToken
       validateClientToken(this.clientToken, this.docId)
@@ -201,6 +200,7 @@ export class YSweetProvider {
     this.awareness.on('update', this.handleAwarenessUpdate.bind(this))
     this.WebSocketPolyfill = extraOptions.WebSocketPolyfill || WebSocket
 
+    this.handleBeforeUnload = this.handleBeforeUnload.bind(this)
     this.online = this.online.bind(this)
     this.offline = this.offline.bind(this)
     if (typeof window !== 'undefined') {

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -94,6 +94,9 @@ export type YSweetProviderParams = {
 
   /** Whether to show the debugger link. Defaults to true. */
   showDebuggerLink?: boolean
+
+  /** Whether to warn when closing tab with unsynchronized changes. Defaults to false. */
+  warnOnClose?: boolean
 }
 
 function validateClientToken(clientToken: ClientToken, docId: string) {
@@ -183,6 +186,7 @@ export class YSweetProvider {
     private doc: Y.Doc,
     extraOptions: Partial<YSweetProviderParams> = {},
   ) {
+    this.handleBeforeUnload = this.handleBeforeUnload.bind(this)
     if (extraOptions.initialClientToken) {
       this.clientToken = extraOptions.initialClientToken
       validateClientToken(this.clientToken, this.docId)
@@ -202,6 +206,9 @@ export class YSweetProvider {
     if (typeof window !== 'undefined') {
       window.addEventListener('offline', this.offline)
       window.addEventListener('online', this.online)
+      if (extraOptions.warnOnClose) {
+        window.addEventListener('beforeunload', this.handleBeforeUnload)
+      }
     }
 
     if (extraOptions.offlineSupport === true && typeof indexedDB !== 'undefined') {
@@ -453,11 +460,11 @@ export class YSweetProvider {
   }
 
   public disconnect() {
+    this.setStatus(STATUS_OFFLINE)
+
     if (this.websocket) {
       this.websocket.close()
     }
-
-    this.setStatus(STATUS_OFFLINE)
   }
 
   private bindWebsocket(websocket: WebSocket) {
@@ -639,6 +646,7 @@ export class YSweetProvider {
     if (typeof window !== 'undefined') {
       window.removeEventListener('offline', this.offline)
       window.removeEventListener('online', this.online)
+      window.removeEventListener('beforeunload', this.handleBeforeUnload)
     }
   }
 
@@ -681,6 +689,12 @@ export class YSweetProvider {
    */
   get hasLocalChanges() {
     return this.ackedVersion !== this.localVersion
+  }
+
+  private handleBeforeUnload(event: BeforeUnloadEvent) {
+    if (this.hasLocalChanges) {
+      event.preventDefault()
+    }
   }
 
   /**

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -230,6 +230,13 @@ export type YDocProviderProps = {
    * Defaults to `true`.
    */
   offlineSupport?: boolean
+
+  /**
+   * Whether to warn when closing tab with unsynchronized changes.
+   *
+   * Defaults to `false`.
+   */
+  warnOnClose?: boolean
 }
 
 /**
@@ -246,6 +253,7 @@ export function YDocProvider(props: YDocProviderProps) {
       initialClientToken,
       offlineSupport: props.offlineSupport,
       showDebuggerLink: props.showDebuggerLink,
+      warnOnClose: props.warnOnClose,
     })
 
     setCtx({ doc, provider })


### PR DESCRIPTION
This adds a `warnOnClose` parameter to both the `YSweetProvider` and React component. If it is set to `true`, and the user closes the tab, they will see a warning like this:

<img width="1520" alt="Screenshot 2025-02-05 at 10 25 39 AM" src="https://github.com/user-attachments/assets/e011fae7-44c0-456c-bb27-e0e0d461c7bf" />

Also includes a fix for #386