### PR TITLE
Remove null return in YDocProvider to fix SSR

### DIFF
--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -272,8 +272,6 @@ export function YDocProvider(props: YDocProviderProps) {
     }
   }, [props.setQueryParam, docId])
 
-  if (ctx === null) return null
-
   return <YjsContext.Provider value={ctx}>{children}</YjsContext.Provider>
 }
 


### PR DESCRIPTION
This pull request makes a small adjustment to the `YDocProvider` component in `js-pkg/react/src/main.tsx`. The change removes an early return statement that previously returned `null` if `ctx` was `null`, allowing the component to render its children within the `YjsContext.Provider` during SSR.