### PR TITLE
derive Deserialize for ClientToken

### DIFF
--- a/crates/y-sweet-core/src/api_types.rs
+++ b/crates/y-sweet-core/src/api_types.rs
@@ -40,7 +40,7 @@ impl Default for AuthDocRequest {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ClientToken {
     /// The URL compatible with the y-websocket provider. The provider will append
     /// a document ID to this string and establish a WebSocket connection.


### PR DESCRIPTION
makes it easier to consume the ClientToken for other rust libraries