### PR TITLE
Allow to disable GC within documents using env variable/CLI

### DIFF
--- a/crates/y-sweet-worker/Cargo.lock
+++ b/crates/y-sweet-worker/Cargo.lock
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "y-sweet-core"
-version = "0.8.2"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/y-sweet-worker/src/durable_object.rs
+++ b/crates/y-sweet-worker/src/durable_object.rs
@@ -40,15 +40,20 @@ impl YServe {
                 .try_into()
                 .expect("Should be able to convert timeout interval to i64");
 
-            let doc = DocWithSyncKv::new(doc_id, store, move || {
-                let storage = storage.clone();
-                wasm_bindgen_futures::spawn_local(async move {
-                    console_log!("Setting alarm.");
-                    if let Err(e) = storage.0.set_alarm(timeout_interval_ms).await {
-                        console_log!("Error setting alarm: {:?}", e);
-                    }
-                });
-            })
+            let doc = DocWithSyncKv::new(
+                doc_id,
+                store,
+                move || {
+                    let storage = storage.clone();
+                    wasm_bindgen_futures::spawn_local(async move {
+                        console_log!("Setting alarm.");
+                        if let Err(e) = storage.0.set_alarm(timeout_interval_ms).await {
+                            console_log!("Error setting alarm: {:?}", e);
+                        }
+                    });
+                },
+                false,
+            )
             .await
             .map_err(|e| format!("Error creating doc: {:?}", e))?;
 

--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -56,6 +56,9 @@ enum ServSubcommand {
 
         #[clap(long, env = "Y_SWEET_MAX_BODY_SIZE")]
         max_body_size: Option<usize>,
+
+        #[clap(long, default_value = "false", env = "Y_SWEET_SKIP_GC")]
+        skip_gc: bool,
     },
 
     GenAuth {
@@ -88,6 +91,9 @@ enum ServSubcommand {
 
         #[clap(long, env = "Y_SWEET_MAX_BODY_SIZE")]
         max_body_size: Option<usize>,
+
+        #[clap(long, default_value = "false", env = "Y_SWEET_SKIP_GC")]
+        skip_gc: bool,
     },
 }
 
@@ -175,6 +181,7 @@ async fn main() -> Result<()> {
             url_prefix,
             prod,
             max_body_size,
+            skip_gc,
         } => {
             let auth = if let Some(auth) = auth {
                 Some(Authenticator::new(auth)?)
@@ -214,6 +221,7 @@ async fn main() -> Result<()> {
                 token.clone(),
                 true,
                 *max_body_size,
+                *skip_gc,
             )
             .await?;
 
@@ -266,6 +274,7 @@ async fn main() -> Result<()> {
             host,
             checkpoint_freq_seconds,
             max_body_size,
+            skip_gc,
         } => {
             let doc_id = env::var("SESSION_BACKEND_KEY").expect("SESSION_BACKEND_KEY must be set");
 
@@ -312,6 +321,7 @@ async fn main() -> Result<()> {
                 cancellation_token.clone(),
                 false,
                 *max_body_size,
+                *skip_gc,
             )
             .await?;
 


### PR DESCRIPTION
### References

- closes #421 

### Description

Adds an option to disable GC within documents (distinct from GC of documents in multi-document mode) via:
- CLI by passing `--skip-gc` to either of `y-sweet serve` or `y-sweet serve-doc`
- `Y_SWEET_SKIP_GC` environment variable

I was not sure if I should also add the environment variable to `y-sweet-worker` for feature parity but given that it is deprecated I went for a smaller changeset and only added it in the server.

I wonder if the configuration for toggling GC of documents themselves (the `doc_gc` option which is not exposed by clap) would be advisable, but I think it is already possible to configure `checkpoint_freq_seconds` instead which can be set to a very high value that is probably better than turning it off altogether.
