### PR TITLE
fix(s3): treat any 2xx as success in store_request

### DIFF
--- a/crates/y-sweet-core/src/doc_connection.rs
+++ b/crates/y-sweet-core/src/doc_connection.rs
@@ -3,6 +3,7 @@ use crate::sync::{
     self, awareness::Awareness, DefaultProtocol, Message, Protocol, SyncMessage, MSG_SYNC,
     MSG_SYNC_UPDATE,
 };
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
 use yrs::{
     block::ClientID,
@@ -25,6 +26,11 @@ type Callback = Arc<dyn Fn(&[u8]) + 'static + Send + Sync>;
 
 const SYNC_STATUS_MESSAGE: u8 = 102;
 
+/// Source of unique per-process connection IDs, used as the origin of awareness
+/// updates so a connection can recognize (and skip) its own updates when they
+/// are broadcast.
+static NEXT_CONNECTION_ID: AtomicU64 = AtomicU64::new(1);
+
 pub struct DocConnection {
     awareness: Arc<RwLock<Awareness>>,
     #[allow(unused)] // acts as RAII guard
@@ -34,6 +40,7 @@ pub struct DocConnection {
     authorization: Authorization,
     callback: Callback,
     closed: Arc<OnceLock<()>>,
+    connection_id: u64,
 
     /// If the client sends an awareness state, this will be set to its client ID.
     /// It is used to clear the awareness state when a client disconnects.
@@ -71,6 +78,7 @@ impl DocConnection {
         callback: Callback,
     ) -> Self {
         let closed = Arc::new(OnceLock::new());
+        let connection_id = NEXT_CONNECTION_ID.fetch_add(1, Ordering::Relaxed);
 
         let (doc_subscription, awareness_subscription) = {
             let mut awareness = awareness.write().unwrap();
@@ -119,6 +127,12 @@ impl DocConnection {
                     return;
                 }
 
+                // Don't echo an awareness update back to the connection that
+                // sent it; the sender already has that state.
+                if e.origin() == Some(connection_id) {
+                    return;
+                }
+
                 // https://github.com/y-crdt/y-sync/blob/56958e83acfd1f3c09f5dd67cf23c9c72f000707/src/net/broadcast.rs#L59
                 let added = e.added();
                 let updated = e.updated();
@@ -143,6 +157,7 @@ impl DocConnection {
             awareness_subscription,
             authorization,
             callback,
+            connection_id,
             client_id: OnceLock::new(),
             closed,
         }
@@ -212,7 +227,7 @@ impl DocConnection {
                     tracing::warn!("Received awareness update with more than one client");
                 }
                 let mut awareness = a.write().unwrap();
-                protocol.handle_awareness_update(&mut awareness, update)
+                protocol.handle_awareness_update_from(&mut awareness, update, Some(self.connection_id))
             }
             Message::Custom(SYNC_STATUS_MESSAGE, data) => {
                 // Respond to the client with the same payload it sent.
@@ -235,5 +250,82 @@ impl Drop for DocConnection {
             let mut awareness = self.awareness.write().unwrap();
             awareness.remove_state(*client_id);
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::sync::awareness::{AwarenessUpdate, AwarenessUpdateEntry};
+    use crate::sync::MSG_AWARENESS;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use yrs::Doc;
+
+    type Frames = Arc<Mutex<Vec<Vec<u8>>>>;
+
+    fn new_conn(awareness: &Arc<RwLock<Awareness>>) -> (DocConnection, Frames) {
+        let frames: Frames = Arc::default();
+        let conn = {
+            let frames = frames.clone();
+            DocConnection::new(awareness.clone(), Authorization::Full, move |bytes: &[u8]| {
+                frames.lock().unwrap().push(bytes.to_vec());
+            })
+        };
+        // Discard the initial handshake (sync step 1 + initial awareness).
+        frames.lock().unwrap().clear();
+        (conn, frames)
+    }
+
+    fn awareness_message(client_id: ClientID, clock: u32, json: &str) -> Message {
+        let mut clients = HashMap::new();
+        clients.insert(
+            client_id,
+            AwarenessUpdateEntry {
+                clock,
+                json: json.to_string(),
+            },
+        );
+        Message::Awareness(AwarenessUpdate { clients })
+    }
+
+    #[test]
+    fn awareness_update_is_not_echoed_to_sender() {
+        let awareness = Arc::new(RwLock::new(Awareness::new(Doc::new())));
+        let (conn_a, frames_a) = new_conn(&awareness);
+        let (_conn_b, frames_b) = new_conn(&awareness);
+
+        conn_a
+            .handle_msg(&DefaultProtocol, awareness_message(7, 1, "{}"))
+            .unwrap();
+
+        assert!(
+            frames_a.lock().unwrap().is_empty(),
+            "sender must not receive its own awareness update"
+        );
+        let frames_b = frames_b.lock().unwrap();
+        assert_eq!(frames_b.len(), 1, "other connections must receive the update");
+        assert_eq!(frames_b[0][0], MSG_AWARENESS);
+    }
+
+    #[test]
+    fn awareness_removal_on_drop_reaches_remaining_connections() {
+        let awareness = Arc::new(RwLock::new(Awareness::new(Doc::new())));
+        let (_conn_a, frames_a) = new_conn(&awareness);
+        let (conn_b, frames_b) = new_conn(&awareness);
+
+        conn_b
+            .handle_msg(&DefaultProtocol, awareness_message(7, 1, "{}"))
+            .unwrap();
+        frames_a.lock().unwrap().clear();
+
+        // Dropping B removes client 7's state; that change has no connection
+        // origin, so remaining connections must be notified.
+        drop(conn_b);
+        drop(frames_b);
+
+        let frames_a = frames_a.lock().unwrap();
+        assert_eq!(frames_a.len(), 1);
+        assert_eq!(frames_a[0][0], MSG_AWARENESS);
     }
 }

--- a/crates/y-sweet-core/src/store/s3.rs
+++ b/crates/y-sweet-core/src/store/s3.rs
@@ -89,7 +89,10 @@ impl S3Store {
         };
 
         match response.status() {
-            StatusCode::OK => Ok(response),
+            // Accept any 2xx as success. A successful DELETE returns 204 No
+            // Content (not 200), which previously fell through to the catch-all
+            // below and was misreported as a ConnectionError.
+            s if s.is_success() => Ok(response),
             StatusCode::NOT_FOUND => Err(StoreError::DoesNotExist(
                 "Received NOT_FOUND from S3-compatible API.".to_string(),
             )),

--- a/crates/y-sweet-core/src/sync/awareness.rs
+++ b/crates/y-sweet-core/src/sync/awareness.rs
@@ -216,6 +216,17 @@ impl Awareness {
     /// Applies an update (incoming from remote channel or generated using [Awareness::update] /
     /// [Awareness::update_with_clients] methods) and modifies a state of a current instance.
     pub fn apply_update(&mut self, update: AwarenessUpdate) -> Result<(), Error> {
+        self.apply_update_from(update, None)
+    }
+
+    /// Like [Awareness::apply_update], but tags the emitted [Event] with an `origin`
+    /// identifying where the update came from (e.g. a connection ID), so that
+    /// subscribers can avoid echoing an update back to its sender.
+    pub fn apply_update_from(
+        &mut self,
+        update: AwarenessUpdate,
+        origin: Option<u64>,
+    ) -> Result<(), Error> {
         let mut added = Vec::new();
         let mut updated = Vec::new();
         let mut removed = Vec::new();
@@ -279,7 +290,7 @@ impl Awareness {
 
         if let Some(eh) = self.on_update.as_ref() {
             if !added.is_empty() || !updated.is_empty() || !removed.is_empty() {
-                let e = Event::new(added, updated, removed);
+                let e = Event::with_origin(added, updated, removed, origin);
                 eh.trigger(|cb| {
                     cb(self, &e);
                 });
@@ -380,15 +391,34 @@ pub struct Event {
     added: Vec<ClientID>,
     updated: Vec<ClientID>,
     removed: Vec<ClientID>,
+    /// Identifies where the change came from (e.g. a connection ID), if known.
+    /// `None` for changes made directly on this instance (e.g. state removal
+    /// on disconnect).
+    origin: Option<u64>,
 }
 
 impl Event {
     pub fn new(added: Vec<ClientID>, updated: Vec<ClientID>, removed: Vec<ClientID>) -> Self {
+        Self::with_origin(added, updated, removed, None)
+    }
+
+    pub fn with_origin(
+        added: Vec<ClientID>,
+        updated: Vec<ClientID>,
+        removed: Vec<ClientID>,
+        origin: Option<u64>,
+    ) -> Self {
         Event {
             added,
             updated,
             removed,
+            origin,
         }
+    }
+
+    /// The origin passed to [Awareness::apply_update_from], if any.
+    pub fn origin(&self) -> Option<u64> {
+        self.origin
     }
 
     /// Collection of new clients that have been added to an [Awareness] struct, that was not known
@@ -460,6 +490,38 @@ mod test {
         assert_eq!(e_remote.removed.len(), 1);
         assert_eq!(local.clients().get(&1), None);
         assert_eq!(e_remote, e_local);
+        Ok(())
+    }
+
+    #[test]
+    fn apply_update_from_carries_origin() -> Result<(), Box<dyn std::error::Error>> {
+        let (tx, rx) = channel();
+        let mut server = Awareness::new(Doc::with_client_id(0));
+        let _sub = server.on_update(move |_, e| {
+            tx.send(e.clone()).unwrap();
+        });
+
+        let mut update = HashMap::new();
+        update.insert(
+            1,
+            AwarenessUpdateEntry {
+                clock: 1,
+                json: "{}".to_string(),
+            },
+        );
+        server.apply_update_from(AwarenessUpdate { clients: update }, Some(42))?;
+        assert_eq!(rx.try_recv()?.origin(), Some(42));
+
+        let mut update = HashMap::new();
+        update.insert(
+            1,
+            AwarenessUpdateEntry {
+                clock: 2,
+                json: "{\"x\":1}".to_string(),
+            },
+        );
+        server.apply_update(AwarenessUpdate { clients: update })?;
+        assert_eq!(rx.try_recv()?.origin(), None);
         Ok(())
     }
 

--- a/crates/y-sweet-core/src/sync/awareness.rs
+++ b/crates/y-sweet-core/src/sync/awareness.rs
@@ -3,12 +3,23 @@ use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::sync::Arc;
 use thiserror::Error;
+use time::OffsetDateTime;
 use yrs::block::ClientID;
 use yrs::updates::decoder::{Decode, Decoder};
 use yrs::updates::encoder::{Encode, Encoder};
 use yrs::{Doc, Observer, Subscription};
 
 const NULL_STR: &str = "null";
+
+/// How long the metadata (logical clock) of a client is retained after its
+/// state has been removed. Within this window, stale updates from the
+/// disconnected client are still rejected by the clock check in
+/// [Awareness::apply_update]. Matches the `outdatedTimeout` convention of the
+/// reference y-protocols implementation (30s).
+///
+/// Without pruning, a long-lived server-side [Awareness] instance grows by one
+/// `meta` entry for every client that ever connected to the document.
+const DISCONNECTED_META_TTL: time::Duration = time::Duration::seconds(30);
 
 #[cfg(not(feature = "sync"))]
 type AwarenessObserver = Observer<Arc<dyn Fn(&Awareness, &Event) + 'static>>;
@@ -128,6 +139,7 @@ impl Awareness {
     pub fn remove_state(&mut self, client_id: ClientID) {
         let prev_state = self.states.remove(&client_id);
         self.update_meta(client_id);
+        self.prune_disconnected_meta(DISCONNECTED_META_TTL);
         if let Some(eh) = self.on_update.as_ref() {
             if prev_state.is_some() {
                 let e = Event::new(Vec::default(), Vec::default(), vec![client_id]);
@@ -156,6 +168,18 @@ impl Awareness {
                 e.insert(MetaClientState::new(1));
             }
         }
+    }
+
+    /// Drop metadata entries of clients that no longer have a state and whose
+    /// metadata hasn't been touched for `ttl`. The entry of a client that was
+    /// just removed always survives at least one full `ttl` window, so its
+    /// clock keeps guarding against stale updates while they can still arrive.
+    fn prune_disconnected_meta(&mut self, ttl: time::Duration) {
+        let now = OffsetDateTime::now_utc();
+        let states = &self.states;
+        self.meta.retain(|client_id, meta| {
+            states.contains_key(client_id) || now - meta.last_updated < ttl
+        });
     }
 
     /// Returns a serializable update object which is representation of a current Awareness state.
@@ -333,11 +357,20 @@ pub enum Error {
 #[derive(Debug, Clone)]
 struct MetaClientState {
     clock: u32,
+    /// When this entry was last created or bumped. Used by
+    /// [Awareness::prune_disconnected_meta] to expire entries of
+    /// disconnected clients. `OffsetDateTime` (not `std::time::Instant`)
+    /// because y-sweet-worker compiles this crate to wasm32, where
+    /// `Instant::now` panics.
+    last_updated: OffsetDateTime,
 }
 
 impl MetaClientState {
     fn new(clock: u32) -> Self {
-        MetaClientState { clock }
+        MetaClientState {
+            clock,
+            last_updated: OffsetDateTime::now_utc(),
+        }
     }
 }
 
@@ -427,6 +460,102 @@ mod test {
         assert_eq!(e_remote.removed.len(), 1);
         assert_eq!(local.clients().get(&1), None);
         assert_eq!(e_remote, e_local);
+        Ok(())
+    }
+
+    /// Backdate a meta entry so it looks like the client disconnected `secs`
+    /// seconds ago.
+    fn backdate_meta(awareness: &mut Awareness, client_id: ClientID, secs: i64) {
+        let meta = awareness.meta.get_mut(&client_id).unwrap();
+        meta.last_updated -= time::Duration::seconds(secs);
+    }
+
+    #[test]
+    fn remove_state_prunes_stale_disconnected_meta() -> Result<(), Box<dyn std::error::Error>> {
+        let mut server = Awareness::new(Doc::with_client_id(0));
+
+        // Three clients connect and announce a state.
+        for client_id in 1..=3 {
+            let mut update = HashMap::new();
+            update.insert(
+                client_id,
+                AwarenessUpdateEntry {
+                    clock: 1,
+                    json: "{}".to_string(),
+                },
+            );
+            server.apply_update(AwarenessUpdate { clients: update })?;
+        }
+
+        // Clients 1 and 2 disconnect; their meta tombstones age past the TTL.
+        server.remove_state(1);
+        server.remove_state(2);
+        backdate_meta(&mut server, 1, 60);
+        backdate_meta(&mut server, 2, 60);
+        assert_eq!(server.meta.len(), 3);
+
+        // The next disconnect prunes the stale tombstones; client 3's own
+        // fresh tombstone and any connected clients' entries survive.
+        server.remove_state(3);
+        assert!(!server.meta.contains_key(&1));
+        assert!(!server.meta.contains_key(&2));
+        assert!(server.meta.contains_key(&3));
+        Ok(())
+    }
+
+    #[test]
+    fn stale_update_still_rejected_within_ttl() -> Result<(), Box<dyn std::error::Error>> {
+        let mut server = Awareness::new(Doc::with_client_id(0));
+
+        let mut update = HashMap::new();
+        update.insert(
+            1,
+            AwarenessUpdateEntry {
+                clock: 5,
+                json: "{}".to_string(),
+            },
+        );
+        server.apply_update(AwarenessUpdate { clients: update })?;
+
+        // Client 1 disconnects. remove_state bumps its meta clock to 6 and
+        // keeps the entry for the TTL window.
+        server.remove_state(1);
+        assert!(server.clients().get(&1).is_none());
+
+        // A delayed update with an older clock must not resurrect the state.
+        let mut stale = HashMap::new();
+        stale.insert(
+            1,
+            AwarenessUpdateEntry {
+                clock: 4,
+                json: "{\"ghost\":true}".to_string(),
+            },
+        );
+        server.apply_update(AwarenessUpdate { clients: stale })?;
+        assert!(server.clients().get(&1).is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn prune_keeps_connected_clients() -> Result<(), Box<dyn std::error::Error>> {
+        let mut server = Awareness::new(Doc::with_client_id(0));
+
+        let mut update = HashMap::new();
+        update.insert(
+            1,
+            AwarenessUpdateEntry {
+                clock: 1,
+                json: "{}".to_string(),
+            },
+        );
+        server.apply_update(AwarenessUpdate { clients: update })?;
+
+        // Even with an ancient last_updated, a client that still has a state
+        // is never pruned.
+        backdate_meta(&mut server, 1, 3600);
+        server.prune_disconnected_meta(DISCONNECTED_META_TTL);
+        assert!(server.meta.contains_key(&1));
+        assert_eq!(server.clients()[&1], "{}");
         Ok(())
     }
 }

--- a/crates/y-sweet-core/src/sync/mod.rs
+++ b/crates/y-sweet-core/src/sync/mod.rs
@@ -121,6 +121,19 @@ pub trait Protocol {
         Ok(None)
     }
 
+    /// Like [Protocol::handle_awareness_update], but tags the update with an `origin`
+    /// identifying the connection it arrived on, so that awareness subscribers can
+    /// avoid echoing the update back to its sender.
+    fn handle_awareness_update_from(
+        &self,
+        awareness: &mut Awareness,
+        update: AwarenessUpdate,
+        origin: Option<u64>,
+    ) -> Result<Option<Message>, Error> {
+        awareness.apply_update_from(update, origin)?;
+        Ok(None)
+    }
+
     /// Y-sync protocol enables to extend its own settings with custom handles. These can be
     /// implemented here. By default, it returns an [Error::Unsupported].
     fn missing_handle(

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -621,9 +621,21 @@ export class YSweetProvider {
 
   private handleAwarenessUpdate(
     { added, updated, removed }: { added: Array<any>; updated: Array<any>; removed: Array<any> },
-    _origin: any,
+    origin: any,
   ) {
-    const changedClients = added.concat(updated).concat(removed)
+    let changedClients = added.concat(updated).concat(removed)
+
+    if (origin === this) {
+      // This update was received from the server, so broadcasting it back
+      // would just echo it. The exception is our own client ID: when a remote
+      // update tries to remove our state, applyAwarenessUpdate keeps the state
+      // and bumps its clock, and that re-assertion must reach the server.
+      changedClients = changedClients.filter((client) => client === this.doc.clientID)
+      if (changedClients.length === 0) {
+        return
+      }
+    }
+
     const encoder = encoding.createEncoder()
     encoding.writeVarUint(encoder, MESSAGE_AWARENESS)
     encoding.writeVarUint8Array(


### PR DESCRIPTION
A successful S3 DELETE returns 204 No Content, not 200. The previous match only accepted StatusCode::OK, so every successful delete fell through to the catch-all arm and was misreported as a ConnectionError ("Received 204 No Content from S3-compatible API."). Accept any 2xx.